### PR TITLE
tsc:test fix for nested build directories

### DIFF
--- a/examples/browserify/test/another.spec.ts
+++ b/examples/browserify/test/another.spec.ts
@@ -2,7 +2,7 @@
 /// <reference path="../api/node/node.d.ts" />
 /// <reference path="../api/jasmine/jasmine.d.ts" />
 
-var Hat:any = require('../src/hat');
+import Hat = require('../src/hat');
 
 describe('another', function():any {
     it('test', function():any {

--- a/examples/browserify/test/hello.spec.ts
+++ b/examples/browserify/test/hello.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path="../api/node/node.d.ts" />
 /// <reference path="../api/jasmine/jasmine.d.ts" />
 
-var Hat:any = require('../src/hat');
+import Hat = require('../src/hat');
 
 describe('hello', function():any {
     it('world', function():any {

--- a/tasks/defaults.js
+++ b/tasks/defaults.js
@@ -69,10 +69,8 @@ module.exports = function(gulp, options, subtasks) {
 
     gulp.desc('tsc:test', 'Transpile TypeScript from test to build_test');
     gulp.task('tsc:test', subtasks.tsc({
-        glob: options.glob.ts,
         cwd: options.path.test,
-        options: options.ts,
-        dest: options.path.build_test
+        dest: options.path.build
     }));
 
     // Tasks that are just a collection of other tasks


### PR DESCRIPTION
### Problem

Described in detail in #7 
### Solution

tsc:test task destination needs to be changed from ./build/test/ to ./build/ by default.
### Testing

*Ensure coverage is working in react-tree project
*Ensure tests work in browserify example (no other examples affected)

@trentgrover-wf 
@shanesizer-wf 
