### PR TITLE
fix tsc paths for sourcemaps/d.ts

### DIFF
--- a/subtasks/tsc.js
+++ b/subtasks/tsc.js
@@ -20,12 +20,16 @@ module.exports = function(gulp, defaults){
                 });
             }
 
-            return stream.pipe(changed(config.dest || defaults.path.build_src))
-                .pipe(tsc(config.options || defaults.ts))
+            var outDir = config.dest || defaults.path.build_src;
+            var tscOptions = config.options || defaults.ts;
+            tscOptions.outDir = outDir;
+
+            return stream.pipe(changed(outDir))
+                .pipe(tsc(tscOptions))
                 .on('error', function(err){
                     cb(new gutil.PluginError('tsc', err));
                 })
-                .pipe(gulp.dest(config.dest || defaults.path.build_src));
+                .pipe(gulp.dest(outDir));
         };
     };
 };


### PR DESCRIPTION
# Summary
- gulp-tsc does some modification to output files to correct relative paths in sourcemap files (.js.map) and declaration files (.d.ts), but it can only do that if 'outDir' option is set to match the path being used for the gulp dest
  - https://github.com/kotas/gulp-tsc#path-modification
# Solution
- modified tsc task to set outDir option
# Testing
- smithy is happy
- verify that tsc task outputs maps 'sources' with the proper relative path to original TS file
  - BEFORE = WRONG
    ![screen shot 2014-09-14 at 12 59 38 am](https://cloud.githubusercontent.com/assets/3778206/4263200/42de4f70-3bd5-11e4-9cad-ebecbf0b8d89.png)
  - AFTER = RIGHT
    ![screen shot 2014-09-14 at 12 58 32 am](https://cloud.githubusercontent.com/assets/3778206/4263201/46e8eeb8-3bd5-11e4-8bcb-8c8b92c0decf.png)
# Code Review

@maxwellpeterson-wf 
FYI @shanesizer-wf @charliekump-wf 
