### PR TITLE
Fix copy:html default task bug.

### DIFF
--- a/tasks/defaults.js
+++ b/tasks/defaults.js
@@ -46,7 +46,7 @@ module.exports = function(gulp, options, subtasks) {
     gulp.desc('copy:html', "Copy HTML from src to build_src");
     gulp.task('copy:html', subtasks.copy({
         glob: options.glob.html,
-        src: options.path.src,
+        cwd: options.path.src,
         changed: true,
         dest: options.path.build_src
     }));


### PR DESCRIPTION
Fixes #23

Reported by @evanweible-wf 
## Problem

The `copy:html` task is defined incorrectly. It specifies a `glob` and a `src` instead of a `glob` and a `cwd`. Because of how the subtask api works, if a `src` is specified, the `glob` and `cwd` are not used.
## Fix

Change `src` option to `cwd`

@trentgrover-wf 
