### PR TITLE
Make gulp bundle synchronously run bundle tasks instead of asynchronously

### DIFF
--- a/tasks/defaults.js
+++ b/tasks/defaults.js
@@ -40,7 +40,7 @@ module.exports = function(gulp, options, subtasks) {
         return taskName;
     });
     gulp.desc('bundle', 'Run all bundle tasks');
-    gulp.task('bundle', bundleTasks);
+    gulp.task('bundle', subtasks.runSequence(bundleTasks));
 
     // Copy tasks
     gulp.desc('copy:html', "Copy HTML from src to build_src");


### PR DESCRIPTION
## Problem

If two `jspm bundle` commands are running at the same time and the `--inject` option is specified in both (so they are both modifying config.js) there is a concurrency issue. Whichever command finishes last will overwrite the changes that previous bundle commands made to config.js
## Solution

Use runSequence to run the bundle tasks synchronously.

This is now what it looks like. Notice how one finishes before the other begins:

``` bash
[12:02:42] Using gulpfile ~/git_workspace/wf/wLoginUI/gulpfile.js
[12:02:42] Starting 'bundle'...
[12:02:42] Starting 'bundle:login'...

     Building the bundle tree for build/src/login...
ok   dist/login.bundle added to config bundles.
ok   Built into dist/login.bundle.js
[12:02:42] Finished 'bundle:login' after 539 ms
[12:02:42] Starting 'bundle:wsr'...

     Building the bundle tree for web-skin-react/cjs/main...
ok   dist/webSkinReact added to config bundles.
ok   Built into dist/webSkinReact.js
[12:02:43] Finished 'bundle:wsr' after 504 ms
[12:02:43] Finished 'bundle' after 1.05 s
```

@trentgrover-wf @evanweible-wf @chadknight-wf 
