### PR TITLE
Gulp task fails if there are no bundles defined

### DIFF
--- a/tasks/defaults.js
+++ b/tasks/defaults.js
@@ -40,7 +40,7 @@ module.exports = function(gulp, options, subtasks) {
         return taskName;
     });
     gulp.desc('bundle', 'Run all bundle tasks');
-    gulp.task('bundle', subtasks.runSequence(bundleTasks));
+    gulp.task('bundle', (bundleTasks && bundleTasks.length > 0) ? subtasks.runSequence(bundleTasks) : null);
 
     // Copy tasks
     gulp.desc('copy:html', "Copy HTML from src to build_src");


### PR DESCRIPTION
# Problem

With release 0.5.2, a project with no bundle tasks defined throws an error
# Solution

Add invalid data check before calling runSequence on non-existent bundle tasks in default.js

@maxwellpeterson-wf - FYI - could we add an integration test around the 0 library scenario?
