### PR TITLE
Add SauceLabs support to wGulp karma runs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,28 @@ gulp test --browsers Chrome,Firefox
 
 *Note:* The `--browsers` option hands the string directly to karma's `browsers: []` configuration, so it is not limited to the three browsers listed above.
 
+### Testing with SauceLabs
+wGulp comes with SauceLabs support so that you can easily run your unit tests in a large number of browsers.
+In order to utilize this feature you will need a SauceLabs account. Configure wGulp with your username and accessKey via customizedOptions:
+
+```js
+var customizedOptions = {
+    sauceLabs: {
+        testName: "Some identifier of your project/test run",
+        username: "your-sauce-username",
+        accessKey: "your-sauce-accessKey"
+    }
+};
+```
+
+After that is configured, it is easy to use it.
+
+```
+gulp test --sauce
+```
+
+If you would like to customize the browsers that your tests get run in, add a `browsers` key to the sauceLabs config. Its value should be an object containing karma-sauce-launcher configs. See the karma-sauce-launcher [documentation](https://github.com/karma-runner/karma-sauce-launcher#adding-karma-sauce-launcher-to-an-existing-karma-config) for more information.
+
 
 ## Customization
 You can now customize the configuration of wGulp by editing `gulpfile.js`:

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-requirejs": "^0.2.2",
+    "karma-sauce-launcher": "^0.2.10",
     "lodash": "^2.4.1",
     "merge-stream": "^0.1.5",
     "mkdirp": "^0.5.0",

--- a/src/gulpconfig.json
+++ b/src/gulpconfig.json
@@ -50,5 +50,42 @@
         "tmpDir": "/tmp/",
         "noLib": false
     },
-    "port": 9000
+    "port": 9000,
+    "sauceLabs": {
+        "testName": "Unit test run through wGulp",
+        "browsers": {
+            "sl_chrome": {
+                "base": "SauceLabs",
+                "browserName": "chrome"
+            },
+            "sl_firefox": {
+                "base": "SauceLabs",
+                "browserName": "firefox"
+            },
+            "sl_ios_safari": {
+                "base": "SauceLabs",
+                "browserName": "safari",
+                "platform": "OS X 10.9",
+                "version": "7"
+            },
+            "sl_ie_9": {
+                "base": "SauceLabs",
+                "browserName": "internet explorer",
+                "platform": "Windows 7",
+                "version": "9"
+            },
+            "sl_ie_10": {
+                "base": "SauceLabs",
+                "browserName": "internet explorer",
+                "platform": "Windows 7",
+                "version": "10"
+            },
+            "sl_ie_11": {
+                "base": "SauceLabs",
+                "browserName": "internet explorer",
+                "platform": "Windows 7",
+                "version": "11"
+            }
+        }
+    }
 }

--- a/tasks/karma.js
+++ b/tasks/karma.js
@@ -42,6 +42,8 @@ module.exports = function(gulp, options, subtasks) {
             action: 'run',
             configFile: options.karma
         };
+
+        // Determine which browsers to run in based on CLI options
         if(argv.browsers){
             karmaOptions.browsers = argv.browsers.split(',');
         }
@@ -55,6 +57,18 @@ module.exports = function(gulp, options, subtasks) {
             }
             if(argv.phantom || argv.p){
                 karmaOptions.browsers.push('PhantomJS');
+            }
+        }
+
+        // Add SauceLabs configuration if user specified --sauce option
+        if(argv.sauce && options.sauceLabs && options.sauceLabs.browsers){
+            karmaOptions.customLaunchers = options.sauceLabs.browsers;
+            karmaOptions.browsers = Object.keys(options.sauceLabs.browsers);
+            karmaOptions.reporters = ['dots', 'saucelabs'];
+            karmaOptions.sauceLabs = {
+                username: options.sauceLabs.username,
+                accessKey: options.sauceLabs.accessKey,
+                testName: options.sauceLabs.testName
             }
         }
 

--- a/tasks/watch_test.js
+++ b/tasks/watch_test.js
@@ -37,6 +37,8 @@ module.exports = function(gulp, options, subtasks) {
             action: 'start',
             configFile: options.karma
         };
+
+        // Determine which browsers to run in based on CLI options
         if(argv.browsers){
             karmaOptions.browsers = argv.browsers.split(',');
         }


### PR DESCRIPTION
## Description

Users should be able to run unit tests in a number of different browsers via SauceLabs with minimal configuration.
wf-grunt has this feature, let's bring it to wGulp as well!

This comes with a default configuration in terms of which browsers tests will be run in. This is overridable just like all wGulp configuration options, in case projects would like to add other browsers. By default they get:
- Newest Chrome
- Newest Firefox
- Safari 7
- IE 9-11 on Windows 7
## Testing

You'll need a project with some unit tests to +10 this.
Simply follow the README additions to configure wGulp with your SauceLabs username and accessKey.

Then run `gulp test --sauce` to run tests via SauceLabs.

_Note:_ Don't forget to npm install in your wGulp project (if you are npm link-ing) as this adds a karma plugin.

@trentgrover-wf 
@shanesizer-wf 
FYI
@evanweible-wf 
@charliekump-wf 
