### PR TITLE
Upgrade to karma-jspm 1.0.0

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,9 +18,6 @@ module.exports = function(karma) {
         preprocessors: {
             'build/src/**/*.js': ['coverage']
         },
-        proxies: {
-            '/jspm_packages/': '/base/jspm_packages/'
-        },
         reporters: ['progress', 'junit', 'html', 'coverage'],
         junitReporter: {
             outputFile: './report/tests/test-results.xml'

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "karma-jasmine": "^0.2.2",
     "karma-jasmine-html-reporter": "^0.1.5",
     "karma-jasmine-html-reporter-livereload": "^1.0.0",
-    "karma-jspm": "0.0.5",
+    "karma-jspm": "1.0.0",
     "karma-junit-reporter": "^0.2.2",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-requirejs": "^0.2.2",

--- a/template/karma.conf.js
+++ b/template/karma.conf.js
@@ -9,9 +9,6 @@ module.exports = function(config) {
         preprocessors: {
             'build/src/**/*.js': ['coverage']
         },
-        proxies: {
-            '/jspm_packages/': '/base/jspm_packages/'
-        },
         reporters: ['progress', 'junit', 'html', 'coverage'],
         junitReporter: {
             outputFile: './report/tests/test-results.xml'


### PR DESCRIPTION
## Description

karma-jspm 1.0.0 was tagged yesterday. This PR bumps that dependency version and removes the Karma proxy configuration that is no longer required as a result of the upgrade.
## Testing

Test this with any project that runs tests using wGulp. I would suggest the jspm-testing example within wGulp or a project like react-tree

@trentgrover-wf 
FYI
@evanweible-wf 
@shanesizer-wf 
@charliekump-wf 
