### PR TITLE
Remove license header from init script

### DIFF
--- a/src/init.js
+++ b/src/init.js
@@ -1,19 +1,3 @@
-/*
- * Copyright 2014 Workiva, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #!/usr/bin/env node
 
 var fs = require('fs');


### PR DESCRIPTION
## Problem

The init script doesn't work with the license there.
## Solution

Remove the license header
## Testing

Ensure `./node_modules/.bin/gulp-init` works.

@trentgrover-wf 
