### PR TITLE
Allow Karma to serve .map files by default

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(karma) {
         frameworks: ['jspm', 'jasmine'],
         jspm: {
             loadFiles: ['build/test/**/*.js'],
-            serveFiles: ['build/src/**/*.js', 'build/src/**/*.map', 'build/test/**/*.map', 'src/**/*.ts', 'test/**/*.ts']
+            serveFiles: ['build/**', 'src/**', 'test/**']
         },
         reporters: ['progress', 'junit', 'html'],
         junitReporter: {

--- a/src/template/karma.conf.js
+++ b/src/template/karma.conf.js
@@ -4,7 +4,7 @@ module.exports = function(config) {
         frameworks: ['jspm', 'jasmine'],
         jspm: {
             loadFiles: ['build/test/**/*.js'],
-            serveFiles: ['build/src/**/*.js', 'build/src/**/*.map', 'build/test/**/*.map', 'src/**/*.ts', 'test/**/*.ts']
+            serveFiles: ['build/**', 'src/**', 'test/**']
         },
         reporters: ['progress', 'junit', 'html'],
         junitReporter: {


### PR DESCRIPTION
Fixes #68 
## Problem

.map files were not in the karma configuration for files that karma can serve. This causes sourcemaps not to work when running test watches in Chrome
## Solution

Add the proper config for *.map files.
## Testing

You can use react-tree or any TypeScript project to test.
- Run `gulp watch:test -c`
- Chrome will open and run the tests. Open developer tools and check the network tab. You should see some .map files are successfully requested.

@trentgrover-wf 
@evanweible-wf 
@charliekump-wf 

FYI - @patkujawa-wf 
