### PR TITLE
Swallow .baseDir.ts temp file deletion error statement

### DIFF
--- a/src/subtasks/tsc.js
+++ b/src/subtasks/tsc.js
@@ -64,7 +64,14 @@ module.exports = function(gulp, defaults){
                 })
                 .on('end', function(){
                     // delete the temporary src TS file
-                    fs.unlink(baseDirFile);
+                    fs.unlink(baseDirFile, function (err) {
+                        // Swallow the error if the file no longer exists.
+                        // Multiple tsc tasks can operate concurrently, so it's
+                        // possible that another tsc task will have completed and
+                        // subsequently deleted this temporary file before this
+                        // tsc task completes (does not adversely affect the
+                        // functionality).
+                    });
                 })
                 .pipe(gulp.dest(outDir));
         };


### PR DESCRIPTION
## Problem

With new task tree implementation, TSC tasks now echo a console error:
`fs: missing callback Error: ENOENT, unlink '/Volumes/CASE/code/wGulp/examples/browserify/src/.baseDir.ts'`
## Solution

Multiple tsc tasks can now operate concurrently, so it's possible that another tsc task will have completed and subsequently deleted this temporary `.baseDir.ts` file before the current tsc task completes.  The error pops up when 1 of these tsc tasks finishes and tries to delete the temp file, which no longer exists.

It doesn't adversely affect the tsc task for the `.baseDir.ts` to be deleted in the middle of its operation (only needs to exist at the beginning of the task), so we can just swallow the error.
## Testing (How to +10)
- Tests should pass
- Examples should still work and no longer display the above error in the console output from `gulp`

@evanweible-wf 
@maxwellpeterson-wf 
