### PR TITLE
Add styles to watched directories for watch task

### DIFF
--- a/src/tasks/watchBuild.js
+++ b/src/tasks/watchBuild.js
@@ -21,9 +21,10 @@ module.exports = function(gulp, options, subtasks) {
     gulp.desc(taskname, 'Watch source files for changes and rebuild');
 
     var fn = function(done) {
-        gulp.watch(options.glob.all, {
-            cwd: options.path.src
-        }, ['build']);
+        gulp.watch([
+            options.path.src + options.glob.all,
+            options.path.styles + options.glob.all
+        ], ['build']);
     };
     gulp.task(taskname, ['build'], fn);
 };


### PR DESCRIPTION
Fixes #80 
## Problem

`buildStyles` is not being watched, so changing a `.sass` or `.scss` file in `buildStyles` will not trigger a rebuild.
## Solution

Add the path.
## Testing
- Create a `.scss` or `.sass` file in a `sass` directory (the default path setting for `buildStyles` )
- Start a `gulp watch`
- Edit the sass file, ensure there is a rebuild triggered upon save

@trentgrover-wf 
@evanweible-wf 
FYI
@brentechols-wf 
