### PR TITLE
Watch:test task references outdated test:generate task

### DIFF
--- a/src/tasks/watchTest.js
+++ b/src/tasks/watchTest.js
@@ -38,7 +38,7 @@ module.exports = function(gulp, options, subtasks) {
         var srcJsx = options.path.src + options.glob.jsx;
         var buildJs = options.path.build + options.glob.js;
 
-        gulp.watch([testJs, testTs, srcJs, srcTs, srcJsx], ['test:generate']);
+        gulp.watch([testJs, testTs, srcJs, srcTs, srcJsx], ['preTest']);
         gulp.watch(buildJs).on('change', server.changed);
 
         // get files from karma config
@@ -74,5 +74,5 @@ module.exports = function(gulp, options, subtasks) {
         return gulp.src(files)
             .pipe(karma(karmaOptions));
     };
-    gulp.task(taskname, ['test:generate'], fn);
+    gulp.task(taskname, ['preTest'], fn);
 };


### PR DESCRIPTION
## Problem

With the camelCase refactor (https://github.com/Workiva/wGulp/pull/73), a reference to the old `test:generate` task was left in the `watch:test` task definition, causing all `watch:test` runs to fail.
## Solution

Update references of `test:generate` to `preTest`.
## How to Test / +10
- Pull down this branch
- Navigate to `jspm-testing` example
- `npm install && jspm install && gulp watch:test` (this installs the wGulp#master)
- Note that `gulp watch:test` fails
- `npm install --save-dev ../../../wGulp` (installs the local version of wGulp - the watchTestFix branch)
- run `gulp watch:test` again, should succeed

---

@maxwellpeterson-wf 
@trentgrover-wf 
@charliekump-wf 
