### PR TITLE
Add task for copying html templates in test to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Out of the box wGulp provides a *lot* of functionality. It is a collection of be
     coffee - Transpile CoffeeScript to JavaScript
     compass - compile sass css (using compass)
     copy:html - Copy html templates in ./src/ to ./build/src/
+    copy:htmltest - Copy html templates in ./test/ to ./build/test/
     copy:js - Copy JavaScript files in ./src/ to ./build/src/
     copy:jstest - Copy JavaScript files in ./test/ to ./build/test/
     cover - Generate and view code coverage report

--- a/src/gulpconfig.json
+++ b/src/gulpconfig.json
@@ -54,6 +54,7 @@
         "connect": [],
         "copy": ["clean:buildSrc", "clean:buildStyles", "clean:buildTest"],
         "copy:html": ["clean:buildSrc"],
+        "copy:htmltest": ["clean:buildTest"],
         "copy:js": ["clean:buildSrc"],
         "copy:jstest": ["clean:buildTest"],
         "cover": ["test"],
@@ -80,7 +81,7 @@
         "bundle": ["clean:dist", "build"],
         "default": ["clean", "build", "test", "analyze", "jsdoc", "dist"],
         "dist": ["clean", "build", "minify", "bundle", "libraryDist"],
-        "preTest": ["build", "tsc:test", "copy:jstest"],
+        "preTest": ["build", "tsc:test", "copy:htmltest", "copy:jstest"],
         "test": ["preTest", "karma"],
         "test:jasmine": ["preTest", "jasmine"]
     },

--- a/src/tasks/defaults.js
+++ b/src/tasks/defaults.js
@@ -103,6 +103,14 @@ module.exports = function(gulp, options, subtasks) {
         changed: true
     }));
 
+    gulp.desc('copy:htmltest', 'Copy HTML from test to buildTest');
+    gulp.task('copy:htmltest', getDeps(options, 'copy:htmltest'), subtasks.copy({
+        glob: options.glob.html,
+        cwd: options.path.test,
+        changed: true,
+        dest: options.path.buildTest
+    }));
+
     gulp.desc('copy:jstest', 'Copy JS from test to buildTest');
     gulp.task('copy:jstest', getDeps(options, 'copy:jstest'), subtasks.copy({
         glob: options.glob.js,


### PR DESCRIPTION
Fixes #88
## Problem

Consumers who have html templates in their test directory have to manually add a task to copy html templates in test to build.
## Solution

Add the task and entry in README
## Testing
- Add a `.html` file to the test dir
- Verify it gets copied to build/test after running `gulp test`

@evanweible-wf 
@trentgrover-wf 
