### PR TITLE
Echo a system bell on all errors to alert the user

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,11 @@ module.exports = function(gulp, userConfig){
         options.isDist = _.contains(e.message.split(','), 'dist');
     });
 
+    // Echo a system bell on all errors to alert the user
+    gulp.on('err', function(e){
+        console.log("\u0007");
+    });
+
     // Check for circular dependencies (cycles) in resulting taskTree
     function detectCycle(task, key, val){
         if(_.contains(val, task)){


### PR DESCRIPTION
Fixes #84
## Problem

Sometimes the user may not know that a wGulp watch or task has failed. 
## Solution

Alert them with a system bell.
## Testing
- Create some error scenario:
  - Missing JSX closing tag
  - Violate jshint or tslint rule
- Listen for the bell on a build

@trentgrover-wf 
@evanweible-wf 

FYI: @patkujawa-wf 
