### PR TITLE
Log filename that JSX parsing error occurred in

### DIFF
--- a/src/subtasks/jsx.js
+++ b/src/subtasks/jsx.js
@@ -16,9 +16,9 @@
 
 function removeCwd(path){
     var cwd = process.cwd();
-    var i = path.indexOf(cwd);
-    if(i != -1){
-        return path.substring(path.indexOf(cwd) + cwd.length);
+    var index = path.indexOf(cwd);
+    if(index != -1){
+        return path.substring(index + cwd.length);
     }
     return path;
 }


### PR DESCRIPTION
Fixes #79
## Problem

If there is an error parsing JSX, it only tells you a line number and not the file that the parsing error was in. This makes it difficult to figure out where the error is in your codebase.
## Solution

The fileName is available in the error object that gets piped through the stream, we just need to add a logging statement to make it visible.
Also added logic to strip off the `cwd` from the file path to make it easier to read (was full path from root of filesystem).
## Testing
- Cause a JSX parse error
- Check to be sure the output looks like this on a build:

![screenshot](http://content.screencast.com/users/max.peterson/folders/Jing/media/ca26ad8f-7cc8-4057-9af2-8d7506244bc7/00001185.png)

@evanweible-wf 
@trentgrover-wf 

FYI: @brentechols-wf 
