### PR TITLE
Allow ES6 syntax in jshint rules

### DIFF
--- a/src/template/.jshintrc
+++ b/src/template/.jshintrc
@@ -22,6 +22,7 @@
     "camelcase": true,
     "curly": true,
     "eqeqeq": true,
+    "esnext": true,
     "forin": true,
     "immed": true,
     "indent": 4,


### PR DESCRIPTION
## Problem

ES6 syntax causes our default jshint rules to complain.
## Solution

Add esnext rule to .jshintrc

@trentgrover-wf 
@evanweible-wf 
