### PR TITLE
Disable camelCase rule. Allow console. Allow Promise to be shadowed

### DIFF
--- a/src/template/.jshintrc
+++ b/src/template/.jshintrc
@@ -14,12 +14,14 @@
         "runs",
         "waits",
         "waitsFor",
-        "spyOn"
+        "spyOn",
+        "console",
+        "-Promise"
     ],
     "browser": true,
 
     "asi": false,
-    "camelcase": true,
+    "camelcase": false,
     "curly": true,
     "eqeqeq": true,
     "esnext": true,


### PR DESCRIPTION
Fixes #100 
## Description

Per discussion in the H5/JS Architecture chat, we should not enforce this rule by default. It adds unnecessary pain when most all of the data we get from REST is in snake_case format.

Also allowing 'console'. It is too painful to create a new .jshintrc file for your project or add a jshint ignore comment when you just want to console.log something quickly.

Also allowing shadowing of built-in Promise (which is specified in es6). Eventually we could just remove the `var Promise = require('es6-promise')` when switching to ES6 and not have to update all our code referencing `Promise`.
## How to +10

Shouldn't need to manually verify that jshint follows its own rule definitions

@trentgrover-wf 
@evanweible-wf 
