### PR TITLE
CP-328 Create src,test dirs on gulp-init, add detail to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,7 @@ Using wGulp
 
 The best and quickest way to get value out of wGulp is to adhere to a standard directory structure (which can be overridden for legacy projects).
 
-* `./src` - TypeScript or JavaScript source code
 * `./api` - TypeScript definition files (see [Centralized APIs with TypeScript Definition Files](#centralized-apis-with-typescript-definition-files))
-* `./test` - TypeScript or JavaScript test specs, written with Jasmine
-* `./sass` - Default location for OOCSS styles
 * `./build` - Assets generated via build
     - `./build/src` - Destination for transpiled/copied source code (from `./src`)
     - `./build/test` - Destination for transpiled/copied test spec code (from `./test`)
@@ -77,6 +74,9 @@ The best and quickest way to get value out of wGulp is to adhere to a standard d
 * `./dist` - Destination for generated distribution assets
 * `./docs` - Destination for generated documentation
 * `./report` - Destination for generated reports (coverage, complexity, test)
+* `./sass` - Default location for OOCSS styles
+* `./src` - TypeScript, JavaScript, JSX, Coffee, ... source code
+* `./test` - TypeScript or JavaScript test specs, written with Jasmine
 
 ### See what's included out of the box
 ```

--- a/src/init.js
+++ b/src/init.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var mkdir = require('mkdirp');
 
 function copy(src, target) {
     console.log('> Creating initial ' + target);
@@ -10,3 +11,7 @@ function copy(src, target) {
 }
 
 copy('node_modules/wGulp/src/template/gulpfile.js', path.resolve(process.cwd(), 'gulpfile.js'));
+['src','test'].forEach(function(dir) {
+    mkdir.sync(path.resolve(process.cwd(), dir));
+});
+

--- a/test/integration/modes/browserify/fixtures/app.js
+++ b/test/integration/modes/browserify/fixtures/app.js
@@ -365,7 +365,6 @@ module.exports = BeforeInputEventPlugin;
  */
 var isUnitlessNumber = {
   columnCount: true,
-  fillOpacity: true,
   flex: true,
   flexGrow: true,
   flexShrink: true,
@@ -377,7 +376,11 @@ var isUnitlessNumber = {
   orphans: true,
   widows: true,
   zIndex: true,
-  zoom: true
+  zoom: true,
+
+  // SVG-related properties
+  fillOpacity: true,
+  strokeOpacity: true
 };
 
 /**
@@ -3617,7 +3620,11 @@ var HTMLDOMPropertyConfig = {
     draggable: null,
     encType: null,
     form: MUST_USE_ATTRIBUTE,
+    formAction: MUST_USE_ATTRIBUTE,
+    formEncType: MUST_USE_ATTRIBUTE,
+    formMethod: MUST_USE_ATTRIBUTE,
     formNoValidate: HAS_BOOLEAN_VALUE,
+    formTarget: MUST_USE_ATTRIBUTE,
     frameBorder: MUST_USE_ATTRIBUTE,
     height: MUST_USE_ATTRIBUTE,
     hidden: MUST_USE_ATTRIBUTE | HAS_BOOLEAN_VALUE,
@@ -3632,6 +3639,8 @@ var HTMLDOMPropertyConfig = {
     list: MUST_USE_ATTRIBUTE,
     loop: MUST_USE_PROPERTY | HAS_BOOLEAN_VALUE,
     manifest: MUST_USE_ATTRIBUTE,
+    marginHeight: null,
+    marginWidth: null,
     max: null,
     maxLength: MUST_USE_ATTRIBUTE,
     media: MUST_USE_ATTRIBUTE,
@@ -4322,7 +4331,7 @@ if ("production" !== process.env.NODE_ENV) {
 
 // Version exists only in the open-source version of React, not in Facebook's
 // internal version.
-React.version = '0.12.1';
+React.version = '0.12.2';
 
 module.exports = React;
 
@@ -9606,7 +9615,7 @@ ReactElement.createElement = function(type, config, children) {
   }
 
   // Resolve default props
-  if (type.defaultProps) {
+  if (type && type.defaultProps) {
     var defaultProps = type.defaultProps;
     for (propName in defaultProps) {
       if (typeof props[propName] === 'undefined') {
@@ -9675,6 +9684,7 @@ module.exports = ReactElement;
 
 }).call(this,require('_process'))
 },{"./ReactContext":37,"./ReactCurrentOwner":38,"./warning":147,"_process":2}],55:[function(require,module,exports){
+(function (process){
 /**
  * Copyright 2014, Facebook, Inc.
  * All rights reserved.
@@ -9700,6 +9710,7 @@ var ReactPropTypeLocations = require("./ReactPropTypeLocations");
 var ReactCurrentOwner = require("./ReactCurrentOwner");
 
 var monitorCodeUse = require("./monitorCodeUse");
+var warning = require("./warning");
 
 /**
  * Warn if there's no key explicitly set on dynamic arrays of children or
@@ -9897,6 +9908,15 @@ function checkPropTypes(componentName, propTypes, props, location) {
 var ReactElementValidator = {
 
   createElement: function(type, props, children) {
+    // We warn in this case but don't throw. We expect the element creation to
+    // succeed and there will likely be errors in render.
+    ("production" !== process.env.NODE_ENV ? warning(
+      type != null,
+      'React.createElement: type should not be null or undefined. It should ' +
+        'be a string (for DOM elements) or a ReactClass (for composite ' +
+        'components).'
+    ) : null);
+
     var element = ReactElement.createElement.apply(this, arguments);
 
     // The result can be nullish if a mock or a custom function is used.
@@ -9909,22 +9929,24 @@ var ReactElementValidator = {
       validateChildKeys(arguments[i], type);
     }
 
-    var name = type.displayName;
-    if (type.propTypes) {
-      checkPropTypes(
-        name,
-        type.propTypes,
-        element.props,
-        ReactPropTypeLocations.prop
-      );
-    }
-    if (type.contextTypes) {
-      checkPropTypes(
-        name,
-        type.contextTypes,
-        element._context,
-        ReactPropTypeLocations.context
-      );
+    if (type) {
+      var name = type.displayName;
+      if (type.propTypes) {
+        checkPropTypes(
+          name,
+          type.propTypes,
+          element.props,
+          ReactPropTypeLocations.prop
+        );
+      }
+      if (type.contextTypes) {
+        checkPropTypes(
+          name,
+          type.contextTypes,
+          element._context,
+          ReactPropTypeLocations.context
+        );
+      }
     }
     return element;
   },
@@ -9942,7 +9964,8 @@ var ReactElementValidator = {
 
 module.exports = ReactElementValidator;
 
-},{"./ReactCurrentOwner":38,"./ReactElement":54,"./ReactPropTypeLocations":73,"./monitorCodeUse":138}],56:[function(require,module,exports){
+}).call(this,require('_process'))
+},{"./ReactCurrentOwner":38,"./ReactElement":54,"./ReactPropTypeLocations":73,"./monitorCodeUse":138,"./warning":147,"_process":2}],56:[function(require,module,exports){
 (function (process){
 /**
  * Copyright 2014, Facebook, Inc.
@@ -12317,7 +12340,7 @@ function createInstanceForTag(tag, props, parentType) {
 
 var ReactNativeComponent = {
   createInstanceForTag: createInstanceForTag,
-  injection: ReactNativeComponentInjection,
+  injection: ReactNativeComponentInjection
 };
 
 module.exports = ReactNativeComponent;
@@ -18320,7 +18343,7 @@ module.exports = Hat;
 },{}],150:[function(require,module,exports){
 var React = require('react');
 
-var Hello = React.createClass({displayName: 'Hello',
+var Hello = React.createClass({displayName: "Hello",
     render: function() {
         return React.createElement("div", null, "Hello ", this.props.name);
     }


### PR DESCRIPTION
I added to the gulp-init script so that it creates the src and test directories when run. If you follow the instructions to create a project from scratch and then run gulp, it immediately fails because there is no src directory. 

We could consider moving some of the generator functionality into the gulp-init script.

To test: 
- Checkout this PR branch.
- Create a new directory and cd into it
```
npm init
npm install workiva/wGulp --save-dev
./node_modules/.bin/gulp-init
``` 
It should create the test and src directory.