### PR TITLE
CP-331 Add ability to specify options for the jsx subtask.

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,9 @@ Run js code through the jshint linter. Takes one custom arg:
     emitError - Whether or not to fail/exit on error. Defaults to true
 
 ##### jsx
-Compile React jsx code into JavaScript.
+Compile React jsx code into JavaScript. Takes one custom arg:
+
+    options - An object of options that gets passed to react's transform function. Defaults to `{stripTypes: true}`
 
 ##### livescript
 Transpile code from LiveScript to JavaScript.

--- a/src/subtasks/jsx.js
+++ b/src/subtasks/jsx.js
@@ -27,8 +27,9 @@ module.exports = function(gulp, defaults){
     gulp.desc('jsx', 'Transpile JSX code with React to JS');
 
     return function(config) {
-        if(!config)
+        if(!config) {
             config = {};
+        }
 
         return function (cb) {
             var changed = require('gulp-changed');
@@ -44,8 +45,14 @@ module.exports = function(gulp, defaults){
                 });
             }
 
+            if (!config.options) {
+                config.options = {
+                    stripTypes: true
+                };
+            }
+
             return stream.pipe(changed(config.dest || defaults.path.buildSrc))
-                .pipe(react())
+                .pipe(react(config.options))
                 .on('error', function(err){
                     console.log("Error parsing JSX file: ." + removeCwd(err.fileName));
                     cb(new gutil.PluginError('jsx', err));


### PR DESCRIPTION
## Description

This PR adds the ability to pass options to the jsx subtask that will get passed to react's transform function (documented here: https://github.com/sindresorhus/gulp-react#reactoptions)

It also adds a default options object that is used if one is not specified:

```js
options = {
    stripTypes: true
};
```

## Testing
Could download the Flow examples and try compiling them with wGulp. @dominicfrost-wf might be in a good place to do this quickly

@trentgrover-wf 
@evanweible-wf 
FYI @shanesizer-wf 