### PR TITLE
CP-337 Add jspm bundle options for minify and sourceMaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Adding bundle configurations is easy! Here is a simple example using jspm:
     external - [optional - applies to browserify only] Array of module names to externalize
     addToConfig - [optional - applies to jspm only] true or false. Writes bundle information to config.js, defaults to true
     sfx - [optional - applies to jspm only] If true, create a [self-executing bundle](https://github.com/jspm/jspm-cli#4-creating-a-self-executing-bundle)
+    minify - [optional - applies to jspm only] If true, minifies the bundle contents. Defaults to false
+    sourceMaps - [optional - applies to jspm only] If true, generates source maps for the bundle. Defaults to true
 
 
 ### Centralized APIs with TypeScript Definition Files

--- a/src/bundling/bundleJspm.js
+++ b/src/bundling/bundleJspm.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-function ensureOutputDir(filePath){
+function ensureOutputDir(filePath) {
     var mkdirp = require('mkdirp');
     var path = require('path');
 
@@ -24,13 +24,16 @@ function ensureOutputDir(filePath){
     }
 };
 
-module.exports = function(gulp, options, bundleOptions, cb){
+module.exports = function(gulp, options, bundleOptions, cb) {
     var shell = require('gulp-shell');
 
     var bundleCommand = bundleOptions.sfx ? " bundle-sfx " : " bundle ";
     var entry = bundleOptions.entry || "";
     var output = bundleOptions.output || "";
     var inject = bundleOptions.addToConfig === false ? "" : " --inject";
+    var minify = bundleOptions.minify ? " --minify" : "";
+    var sourceMaps = bundleOptions.sourceMaps === false ? " --skip-source-maps" : "";
+
     var includes = "";
     var excludes = "";
     if(bundleOptions.include && bundleOptions.include.length > 0){
@@ -43,7 +46,7 @@ module.exports = function(gulp, options, bundleOptions, cb){
     // Ensure output directory exists
     ensureOutputDir(output);
 
-    var command = "jspm" + bundleCommand + entry + includes + excludes + " " + output + inject;
+    var command = "jspm" + bundleCommand + entry + includes + excludes + " " + output + inject + minify + sourceMaps;
 
     return gulp.src('').pipe(shell([command]));
 };


### PR DESCRIPTION
## Description

JSPM now offers the ability to minify bundles and generate sourceMaps when bundling.

This PR adds the option to disable or enable each of these features per-bundle.
Example:

```js
    bundles: {
        app: {
            bundler: 'jspm',
            entry: 'build/src/app',
            output: 'dist/CPDemo.js',
            sfx: true,
            sourceMaps: true,
            minify: true
        }
    }
```

Notice the sourceMaps and minify options at the bottom.

## Testing

* When sourceMaps is true, jspm bundle should output the following:
```bash
     Building the single-file sfx bundle for build/src/app...
ok   Built into dist/CPDemo.js with source maps, unminified.
```
* When sourceMaps is false, jspm bundle should output the following:
```bash
     Building the single-file sfx bundle for build/src/app...
ok   Built into dist/CPDemo.js, unminified.
```
* When minify is true, jspm bundle should output the following:
```bash
     Building the single-file sfx bundle for build/src/app...
ok   Built into dist/CPDemo.js, minified.
```

Tested with CPDemo.

@trentgrover-wf 
@evanweible-wf 
@jayudey-wf 
FYI - @guybedford-wf 