### PR TITLE
CP-367 Do not minify:js in dist by default

### DIFF
--- a/src/gulpconfig.json
+++ b/src/gulpconfig.json
@@ -81,7 +81,7 @@
         "build": ["clean", "lint", "tsd", "jsx", "tsc", "copy:html", "copy:js", "coffee", "livescript", "sass"],
         "bundle": ["clean:dist", "build"],
         "default": ["clean", "build", "test", "analyze", "jsdoc", "dist"],
-        "dist": ["clean", "build", "bundle", "libraryDist", "minify"],
+        "dist": ["clean", "build", "bundle", "libraryDist", "minify:css"],
         "preTest": ["build", "tsc:test", "copy:htmltest", "copy:jstest", "jsx:test"],
         "test": ["preTest", "karma"],
         "test:jasmine": ["preTest", "jasmine"]


### PR DESCRIPTION
## Description

This change is to align with CP team's default library workflow.
We will distribute unminified library files in `dist/`, and a minified globalBundle with sourcemaps in `lib/` for Dart consumption. That minification is done by jspm itself during the bundling process.

## Testing

install that branch of wGulp in some project and run `gulp dist` and make sure it doesn't run the minify:js task

@trentgrover-wf 
@evanweible-wf 