### PR TITLE
CP-397 Add excludeFromAll feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ taskTree: {
 }
 ```
 
+##### Exclude from every task
+The above configuration is useful, however it may become annoying if you are attempting to exclude a task from everything that depends on it.
+wGulp now supports an `excludeFromAll` feature that will simplify the above like so:
+
+```js
+taskTree: {
+    excludeFromAll: ['libraryDist']
+}
+```
+
+The `excludeFromAll` option takes least precedence when determining dependencies. So if you explicitly include something for a specific task, that will override the `excludeFromAll` for that particular case.
+
 #### Using the Dependency Tree in a Custom Task
 Perhaps you want to utilize the dependency tree when defining your own task. wGulp exposes the `getDeps` function for this purpose.
 

--- a/src/depTreeParser.js
+++ b/src/depTreeParser.js
@@ -17,10 +17,14 @@
 module.exports = function(options, key){
     var _ = require('lodash');
     var depsEntry = options.taskTree[key];
+    var excludeFromAll = options.taskTree.excludeFromAll || [];
+
     if(_.isArray(depsEntry)){
-        return depsEntry;
-    } else if(_.isObject(depsEntry)){
+        return _.difference(depsEntry, excludeFromAll);
+    }
+    else if(_.isObject(depsEntry)){
         var baseTasks = depsEntry.tasks;
+        baseTasks = _.difference(baseTasks, excludeFromAll);
         baseTasks = _.difference(baseTasks, depsEntry.exclude || []);
         baseTasks = _.union(baseTasks, depsEntry.include || []);
         return baseTasks;

--- a/src/gulpconfig.json
+++ b/src/gulpconfig.json
@@ -40,6 +40,7 @@
     "transforms": [],
     "bundles": {},
     "taskTree": {
+        "excludeFromAll": [],
         "analyze": ["build"],
         "applyLicense": [],
         "clean": ["clean:buildSrc", "clean:buildStyles", "clean:buildTest", "clean:dist"],


### PR DESCRIPTION
## Problem

It is cumbersome to prevent some task from running. Currently you would have to figure out which tasks depend on it, and explicitly exclude it from each, like so:

*Trying to remove the `libraryDist` task*
```js
taskTree: {
    dist: {
        exclude: ['libraryDist']
    },
    "minify:css": {
        exclude: ['libraryDist']
    },
    "minify:js": {
        exclude: ['libraryDist']
    },
}
```

## Solution

Support a special-case taskTree option to exclude a task from all. Reduces the above case to this:

```js
taskTree: {
    excludeFromAll: ['libraryDist']
}
```

Note that includes take precedence. So this will still work:

```js
taskTree: {
    excludeFromAll: ['libraryDist'],
    fullDist: {
        include: ['libraryDist']
    }
}
```

Fixes #113 

## Testing instructions

install this version of wGulp add excludeFromAll to the task tree and make sure that task are being properly excluded

@trentgrover-wf 
@evanweible-wf 