### PR TITLE
ATEAM-1009: pull in newer typescript version for union types

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react": "^0.12.1",
     "requirejs": "^2.1.14",
     "source-map": "^0.1.33",
-    "typescript": "1.0.1",
+    "typescript": "1.4.1",
     "vinyl-source-stream": "^1.0.0",
     "yargs": "^1.2.1"
   },


### PR DESCRIPTION
CODE REVIEW for https://jira.webfilings.com/browse/ATEAM-1009

***

Updated `package.json` to pull in [latest typescript version](https://www.npmjs.com/package/typescript) - `1.4.1` - to support https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#union-types. Needed for latest [`knockout.d.ts`](https://github.com/borisyankov/DefinitelyTyped/blob/master/knockout/knockout.d.ts) in https://github.com/Workiva/w-annotation-js-ui.
