### PR TITLE
CP-436 Pin Phantomjs to 1.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mkdirp": "^0.5.0",
     "open": "0.0.5",
     "partialify": "^3.1.1",
+    "phantomjs": "1.9.15",
     "react": "^0.12.1",
     "requirejs": "^2.1.14",
     "source-map": "^0.1.33",


### PR DESCRIPTION
Because 1.9.16 breaks smithy builds.

Currently wGulp is getting phantomjs through `karma-phantomjs-launcher`. If we specify an exact version here, npm should use it to fulfill `karma-phantomjs-launcher`'s dependency as long as it matches the semver range (which it does).

## Testing

* Checked out this branch
* `git clean -xdf`
* `npm install`
* Inspect output:

```
karma-phantomjs-launcher@0.1.4 node_modules/karma-phantomjs-launcher
...
phantomjs@1.9.15 node_modules/phantomjs
├── which@1.0.9
├── progress@1.1.8
├── kew@0.4.0
├── request-progress@0.3.1 (throttleit@0.0.2)
├── fs-extra@0.16.4 (jsonfile@2.0.0, rimraf@2.2.8, graceful-fs@3.0.5)
├── adm-zip@0.4.4
├── npmconf@2.0.9 (uid-number@0.0.5, osenv@0.1.0, ini@1.3.3, inherits@2.0.1, once@1.3.1, config-chain@1.1.8, nopt@3.0.1, semver@4.3.1)
└── request@2.42.0 (caseless@0.6.0, json-stringify-safe@5.0.0, aws-sign2@0.5.0, forever-agent@0.5.2, stringstream@0.0.4, oauth-sign@0.4.0, tunnel-agent@0.4.0, qs@1.2.2, node-uuid@1.4.2, mime-types@1.0.2, form-data@0.1.4, http-signature@0.10.1, tough-cookie@0.12.1, hawk@1.1.1, bl@0.9.4)
```

Notice karma-phantomjs-launcher did not specify its own version of phantomjs.  phantomjs@1.9.16 is no where to be found :+1: 

FYA:
@trentgrover-wf 
@evanweible-wf 
