### PR TITLE
shrinkwrap wGulp dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,13941 @@
+{
+  "name": "wGulp",
+  "version": "0.7.8",
+  "dependencies": {
+    "LiveScript": {
+      "version": "1.3.1",
+      "from": "LiveScript@^1.3.0",
+      "resolved": "https://npm.webfilings.org/LiveScript/-/LiveScript-1.3.1.tgz",
+      "dependencies": {
+        "prelude-ls": {
+          "version": "1.1.1",
+          "from": "prelude-ls@~1.1.1",
+          "resolved": "https://npm.webfilings.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+        },
+        "optionator": {
+          "version": "0.4.0",
+          "from": "optionator@~0.4.0",
+          "resolved": "https://npm.webfilings.org/optionator/-/optionator-0.4.0.tgz",
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "from": "deep-is@~0.1.2",
+              "resolved": "https://npm.webfilings.org/deep-is/-/deep-is-0.1.3.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "from": "type-check@~0.3.1",
+              "resolved": "https://npm.webfilings.org/type-check/-/type-check-0.3.1.tgz"
+            },
+            "levn": {
+              "version": "0.2.5",
+              "from": "levn@~0.2.5",
+              "resolved": "https://npm.webfilings.org/levn/-/levn-0.2.5.tgz"
+            },
+            "fast-levenshtein": {
+              "version": "1.0.6",
+              "from": "fast-levenshtein@~1.0.0",
+              "resolved": "https://npm.webfilings.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "browserify": {
+      "version": "6.3.4",
+      "from": "browserify@^6.1.0",
+      "resolved": "https://npm.webfilings.org/browserify/-/browserify-6.3.4.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.8.4",
+          "from": "JSONStream@~0.8.3",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+          "dependencies": {
+            "jsonparse": {
+              "version": "0.0.5",
+              "from": "jsonparse@0.0.5",
+              "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@>=2.2.7 <3",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            }
+          }
+        },
+        "assert": {
+          "version": "1.1.2",
+          "from": "assert@~1.1.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+        },
+        "browser-pack": {
+          "version": "3.2.0",
+          "from": "browser-pack@^3.2.0",
+          "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-3.2.0.tgz",
+          "dependencies": {
+            "combine-source-map": {
+              "version": "0.3.0",
+              "from": "combine-source-map@~0.3.0",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "dependencies": {
+                "inline-source-map": {
+                  "version": "0.3.1",
+                  "from": "inline-source-map@~0.3.0",
+                  "resolved": "https://npm.webfilings.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.3.0",
+                      "from": "source-map@~0.3.0",
+                      "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "0.3.5",
+                  "from": "convert-source-map@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@~0.5.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.17",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "browser-resolve": {
+          "version": "1.7.2",
+          "from": "browser-resolve@^1.3.0",
+          "resolved": "https://npm.webfilings.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.5",
+              "from": "resolve@1.1.5",
+              "resolved": "https://npm.webfilings.org/resolve/-/resolve-1.1.5.tgz"
+            }
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@~0.1.2",
+          "resolved": "https://npm.webfilings.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.5",
+              "from": "pako@~0.2.0",
+              "resolved": "https://npm.webfilings.org/pako/-/pako-0.2.5.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "2.8.2",
+          "from": "buffer@^2.3.0",
+          "resolved": "https://npm.webfilings.org/buffer/-/buffer-2.8.2.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.7",
+              "from": "base64-js@0.0.7",
+              "resolved": "https://npm.webfilings.org/base64-js/-/base64-js-0.0.7.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.4",
+              "from": "ieee754@^1.1.4",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+            },
+            "is-array": {
+              "version": "1.0.1",
+              "from": "is-array@^1.0.1",
+              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+            }
+          }
+        },
+        "builtins": {
+          "version": "0.0.7",
+          "from": "builtins@~0.0.3",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+        },
+        "commondir": {
+          "version": "0.0.1",
+          "from": "commondir@0.0.1",
+          "resolved": "https://npm.webfilings.org/commondir/-/commondir-0.0.1.tgz"
+        },
+        "concat-stream": {
+          "version": "1.4.7",
+          "from": "concat-stream@~1.4.1",
+          "resolved": "https://npm.webfilings.org/concat-stream/-/concat-stream-1.4.7.tgz",
+          "dependencies": {
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@~0.0.5",
+              "resolved": "https://npm.webfilings.org/typedarray/-/typedarray-0.0.6.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@^1.1.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@^0.1.4",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@~0.0.1",
+          "resolved": "https://npm.webfilings.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.9.13",
+          "from": "crypto-browserify@^3.0.0",
+          "resolved": "https://npm.webfilings.org/crypto-browserify/-/crypto-browserify-3.9.13.tgz",
+          "dependencies": {
+            "browserify-aes": {
+              "version": "1.0.0",
+              "from": "browserify-aes@^1.0.0",
+              "resolved": "https://npm.webfilings.org/browserify-aes/-/browserify-aes-1.0.0.tgz"
+            },
+            "browserify-sign": {
+              "version": "2.8.0",
+              "from": "browserify-sign@2.8.0",
+              "resolved": "https://npm.webfilings.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "1.3.0",
+                  "from": "bn.js@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/bn.js/-/bn.js-1.3.0.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "1.1.1",
+                  "from": "browserify-rsa@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/browserify-rsa/-/browserify-rsa-1.1.1.tgz"
+                },
+                "elliptic": {
+                  "version": "1.0.1",
+                  "from": "elliptic@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://npm.webfilings.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.2",
+                      "from": "hash.js@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/hash.js/-/hash.js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "parse-asn1": {
+                  "version": "2.0.0",
+                  "from": "parse-asn1@^2.0.0",
+                  "resolved": "https://npm.webfilings.org/parse-asn1/-/parse-asn1-2.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "1.0.3",
+                      "from": "asn1.js@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "asn1.js-rfc3280": {
+                      "version": "1.0.0",
+                      "from": "asn1.js-rfc3280@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/asn1.js-rfc3280/-/asn1.js-rfc3280-1.0.0.tgz"
+                    },
+                    "pemstrip": {
+                      "version": "0.0.1",
+                      "from": "pemstrip@0.0.1",
+                      "resolved": "https://npm.webfilings.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-ecdh": {
+              "version": "2.0.0",
+              "from": "create-ecdh@^2.0.0",
+              "resolved": "https://npm.webfilings.org/create-ecdh/-/create-ecdh-2.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "1.3.0",
+                  "from": "bn.js@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/bn.js/-/bn.js-1.3.0.tgz"
+                },
+                "elliptic": {
+                  "version": "1.0.1",
+                  "from": "elliptic@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/elliptic/-/elliptic-1.0.1.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://npm.webfilings.org/brorand/-/brorand-1.0.5.tgz"
+                    },
+                    "hash.js": {
+                      "version": "1.0.2",
+                      "from": "hash.js@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/hash.js/-/hash.js-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "create-hash": {
+              "version": "1.1.0",
+              "from": "create-hash@^1.1.0",
+              "resolved": "https://npm.webfilings.org/create-hash/-/create-hash-1.1.0.tgz",
+              "dependencies": {
+                "ripemd160": {
+                  "version": "1.0.0",
+                  "from": "ripemd160@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/ripemd160/-/ripemd160-1.0.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.3.6",
+                  "from": "sha.js@^2.3.6",
+                  "resolved": "https://npm.webfilings.org/sha.js/-/sha.js-2.3.6.tgz"
+                }
+              }
+            },
+            "create-hmac": {
+              "version": "1.1.3",
+              "from": "create-hmac@^1.1.0",
+              "resolved": "https://npm.webfilings.org/create-hmac/-/create-hmac-1.1.3.tgz"
+            },
+            "diffie-hellman": {
+              "version": "3.0.1",
+              "from": "diffie-hellman@^3.0.1",
+              "resolved": "https://npm.webfilings.org/diffie-hellman/-/diffie-hellman-3.0.1.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "1.3.0",
+                  "from": "bn.js@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/bn.js/-/bn.js-1.3.0.tgz"
+                },
+                "miller-rabin": {
+                  "version": "1.1.5",
+                  "from": "miller-rabin@^1.1.2",
+                  "resolved": "https://npm.webfilings.org/miller-rabin/-/miller-rabin-1.1.5.tgz",
+                  "dependencies": {
+                    "brorand": {
+                      "version": "1.0.5",
+                      "from": "brorand@^1.0.1",
+                      "resolved": "https://npm.webfilings.org/brorand/-/brorand-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "pbkdf2-compat": {
+              "version": "3.0.2",
+              "from": "pbkdf2-compat@^3.0.1",
+              "resolved": "https://npm.webfilings.org/pbkdf2-compat/-/pbkdf2-compat-3.0.2.tgz"
+            },
+            "public-encrypt": {
+              "version": "2.0.0",
+              "from": "public-encrypt@^2.0.0",
+              "resolved": "https://npm.webfilings.org/public-encrypt/-/public-encrypt-2.0.0.tgz",
+              "dependencies": {
+                "bn.js": {
+                  "version": "1.3.0",
+                  "from": "bn.js@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/bn.js/-/bn.js-1.3.0.tgz"
+                },
+                "browserify-rsa": {
+                  "version": "2.0.0",
+                  "from": "browserify-rsa@^2.0.0",
+                  "resolved": "https://npm.webfilings.org/browserify-rsa/-/browserify-rsa-2.0.0.tgz"
+                },
+                "parse-asn1": {
+                  "version": "3.0.0",
+                  "from": "parse-asn1@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/parse-asn1/-/parse-asn1-3.0.0.tgz",
+                  "dependencies": {
+                    "asn1.js": {
+                      "version": "1.0.3",
+                      "from": "asn1.js@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/asn1.js/-/asn1.js-1.0.3.tgz",
+                      "dependencies": {
+                        "minimalistic-assert": {
+                          "version": "1.0.0",
+                          "from": "minimalistic-assert@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "randombytes": {
+              "version": "2.0.1",
+              "from": "randombytes@^2.0.0",
+              "resolved": "https://npm.webfilings.org/randombytes/-/randombytes-2.0.1.tgz"
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "0.2.2",
+          "from": "deep-equal@~0.2.1",
+          "resolved": "https://npm.webfilings.org/deep-equal/-/deep-equal-0.2.2.tgz"
+        },
+        "defined": {
+          "version": "0.0.0",
+          "from": "defined@~0.0.0",
+          "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+        },
+        "deps-sort": {
+          "version": "1.3.5",
+          "from": "deps-sort@^1.3.5",
+          "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-1.3.5.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@~0.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@~0.5.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.17",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.4",
+          "from": "domain-browser@~1.1.0",
+          "resolved": "https://npm.webfilings.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "duplexer2": {
+          "version": "0.0.2",
+          "from": "duplexer2@~0.0.2",
+          "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz"
+        },
+        "events": {
+          "version": "1.0.2",
+          "from": "events@~1.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "http-browserify@^1.4.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "dependencies": {
+            "Base64": {
+              "version": "0.2.1",
+              "from": "Base64@~0.2.0",
+              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "from": "https-browserify@~0.0.0",
+          "resolved": "https://npm.webfilings.org/https-browserify/-/https-browserify-0.0.0.tgz"
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@~2.0.1",
+          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "insert-module-globals": {
+          "version": "6.2.1",
+          "from": "insert-module-globals@^6.1.0",
+          "resolved": "https://npm.webfilings.org/insert-module-globals/-/insert-module-globals-6.2.1.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.7.4",
+              "from": "JSONStream@~0.7.1",
+              "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                }
+              }
+            },
+            "combine-source-map": {
+              "version": "0.3.0",
+              "from": "combine-source-map@~0.3.0",
+              "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+              "dependencies": {
+                "inline-source-map": {
+                  "version": "0.3.1",
+                  "from": "inline-source-map@~0.3.0",
+                  "resolved": "https://npm.webfilings.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.3.0",
+                      "from": "source-map@~0.3.0",
+                      "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.3.0.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "convert-source-map": {
+                  "version": "0.3.5",
+                  "from": "convert-source-map@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+                }
+              }
+            },
+            "lexical-scope": {
+              "version": "1.1.0",
+              "from": "lexical-scope@~1.1.0",
+              "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+              "dependencies": {
+                "astw": {
+                  "version": "1.1.0",
+                  "from": "astw@~1.1.0",
+                  "resolved": "https://npm.webfilings.org/astw/-/astw-1.1.0.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "3001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "process": {
+              "version": "0.6.0",
+              "from": "process@~0.6.0",
+              "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.4",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            }
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "labeled-stream-splicer": {
+          "version": "1.0.2",
+          "from": "labeled-stream-splicer@^1.0.0",
+          "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-1.0.2.tgz",
+          "dependencies": {
+            "stream-splicer": {
+              "version": "1.3.1",
+              "from": "stream-splicer@^1.1.0",
+              "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-1.3.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@^1.1.13-1",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "readable-wrap": {
+                  "version": "1.0.0",
+                  "from": "readable-wrap@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-wrap/-/readable-wrap-1.0.0.tgz"
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "module-deps": {
+          "version": "3.7.2",
+          "from": "module-deps@^3.5.0",
+          "resolved": "https://npm.webfilings.org/module-deps/-/module-deps-3.7.2.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.7.4",
+              "from": "JSONStream@~0.7.1",
+              "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "detective": {
+              "version": "4.0.0",
+              "from": "detective@^4.0.0",
+              "resolved": "https://npm.webfilings.org/detective/-/detective-4.0.0.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@~0.9.0",
+                  "resolved": "https://npm.webfilings.org/acorn/-/acorn-0.9.0.tgz"
+                },
+                "escodegen": {
+                  "version": "1.6.1",
+                  "from": "escodegen@^1.4.1",
+                  "resolved": "https://npm.webfilings.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "from": "estraverse@^1.9.1",
+                      "resolved": "https://npm.webfilings.org/estraverse/-/estraverse-1.9.3.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "esutils@^1.1.6",
+                      "resolved": "https://npm.webfilings.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.5",
+                      "from": "esprima@^1.2.2",
+                      "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.2.5.tgz"
+                    },
+                    "optionator": {
+                      "version": "0.5.0",
+                      "from": "optionator@^0.5.0",
+                      "resolved": "https://npm.webfilings.org/optionator/-/optionator-0.5.0.tgz",
+                      "dependencies": {
+                        "prelude-ls": {
+                          "version": "1.1.1",
+                          "from": "prelude-ls@~1.1.1",
+                          "resolved": "https://npm.webfilings.org/prelude-ls/-/prelude-ls-1.1.1.tgz"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "from": "deep-is@~0.1.2",
+                          "resolved": "https://npm.webfilings.org/deep-is/-/deep-is-0.1.3.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@~0.0.2",
+                          "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "type-check@~0.3.1",
+                          "resolved": "https://npm.webfilings.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "levn": {
+                          "version": "0.2.5",
+                          "from": "levn@~0.2.5",
+                          "resolved": "https://npm.webfilings.org/levn/-/levn-0.2.5.tgz"
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.0.6",
+                          "from": "fast-levenshtein@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@~0.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "parents": {
+              "version": "1.0.1",
+              "from": "parents@^1.0.0",
+              "resolved": "https://npm.webfilings.org/parents/-/parents-1.0.1.tgz",
+              "dependencies": {
+                "path-platform": {
+                  "version": "0.11.15",
+                  "from": "path-platform@~0.11.15",
+                  "resolved": "https://npm.webfilings.org/path-platform/-/path-platform-0.11.15.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.5",
+              "from": "resolve@^1.1.3",
+              "resolved": "https://npm.webfilings.org/resolve/-/resolve-1.1.5.tgz"
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "stream-combiner2@~1.0.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "through2@~0.5.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.17",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "xtend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "subarg": {
+              "version": "0.0.1",
+              "from": "subarg@0.0.1",
+              "resolved": "https://npm.webfilings.org/subarg/-/subarg-0.0.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.7",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.4.2",
+              "from": "through2@~0.4.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.17",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "2.1.2",
+                  "from": "xtend@~2.1.1",
+                  "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+                  "dependencies": {
+                    "object-keys": {
+                      "version": "0.4.0",
+                      "from": "object-keys@~0.4.0",
+                      "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@^4.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@~0.1.1",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "parents": {
+          "version": "0.0.3",
+          "from": "parents@~0.0.1",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+          "dependencies": {
+            "path-platform": {
+              "version": "0.0.1",
+              "from": "path-platform@^0.0.1",
+              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
+            }
+          }
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@~0.0.0",
+          "resolved": "https://npm.webfilings.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.8.0",
+          "from": "process@^0.8.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.8.0.tgz"
+        },
+        "punycode": {
+          "version": "1.2.4",
+          "from": "punycode@~1.2.3",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@~0.2.0",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.10",
+          "from": "readable-stream@^1.0.33-1",
+          "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "debuglog": {
+              "version": "0.0.2",
+              "from": "debuglog@0.0.2",
+              "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "0.7.4",
+          "from": "resolve@~0.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+        },
+        "shallow-copy": {
+          "version": "0.0.1",
+          "from": "shallow-copy@0.0.1",
+          "resolved": "https://npm.webfilings.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+        },
+        "shasum": {
+          "version": "1.0.1",
+          "from": "shasum@^1.0.0",
+          "resolved": "https://npm.webfilings.org/shasum/-/shasum-1.0.1.tgz",
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "0.0.1",
+              "from": "json-stable-stringify@~0.0.0",
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+              "dependencies": {
+                "jsonify": {
+                  "version": "0.0.0",
+                  "from": "jsonify@~0.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                }
+              }
+            },
+            "sha.js": {
+              "version": "2.3.6",
+              "from": "sha.js@~2.3.0",
+              "resolved": "https://npm.webfilings.org/sha.js/-/sha.js-2.3.6.tgz"
+            }
+          }
+        },
+        "shell-quote": {
+          "version": "0.0.1",
+          "from": "shell-quote@~0.0.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "stream-browserify@^1.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@~0.10.x",
+          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "from": "subarg@^1.0.0",
+          "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            }
+          }
+        },
+        "syntax-error": {
+          "version": "1.1.2",
+          "from": "syntax-error@^1.1.1",
+          "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.9.0",
+              "from": "acorn@~0.9.0",
+              "resolved": "https://npm.webfilings.org/acorn/-/acorn-0.9.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@^1.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.0",
+          "from": "timers-browserify@^1.0.1",
+          "resolved": "https://npm.webfilings.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+          "dependencies": {
+            "process": {
+              "version": "0.10.1",
+              "from": "process@~0.10.0",
+              "resolved": "https://npm.webfilings.org/process/-/process-0.10.1.tgz"
+            }
+          }
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@~0.0.0",
+          "resolved": "https://npm.webfilings.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "umd": {
+          "version": "2.1.0",
+          "from": "umd@~2.1.0",
+          "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+          "dependencies": {
+            "rfile": {
+              "version": "1.0.0",
+              "from": "rfile@~1.0.0",
+              "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+              "dependencies": {
+                "callsite": {
+                  "version": "1.0.0",
+                  "from": "callsite@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/callsite/-/callsite-1.0.0.tgz"
+                },
+                "resolve": {
+                  "version": "0.3.1",
+                  "from": "resolve@~0.3.0",
+                  "resolved": "https://npm.webfilings.org/resolve/-/resolve-0.3.1.tgz"
+                }
+              }
+            },
+            "ruglify": {
+              "version": "1.0.0",
+              "from": "ruglify@~1.0.0",
+              "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+              "dependencies": {
+                "uglify-js": {
+                  "version": "2.2.5",
+                  "from": "uglify-js@~2.2",
+                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                  "dependencies": {
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@~0.3.5",
+                      "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@~0.0.2",
+                          "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.4",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "uglify-js": {
+              "version": "2.4.16",
+              "from": "uglify-js@~2.4.0",
+              "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.6",
+                  "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@~0.3.5",
+                  "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@~0.10.1",
+          "resolved": "https://npm.webfilings.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "https://npm.webfilings.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://npm.webfilings.org/querystring/-/querystring-0.2.0.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@~0.10.1",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@~0.0.1",
+          "resolved": "https://npm.webfilings.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1",
+              "from": "indexof@0.0.1",
+              "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@^3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
+    },
+    "chalk": {
+      "version": "0.5.1",
+      "from": "chalk@^0.5.1",
+      "resolved": "https://npm.webfilings.org/chalk/-/chalk-0.5.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "ansi-styles@^1.1.0",
+          "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "from": "escape-string-regexp@^1.0.0",
+          "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "has-ansi@^0.1.0",
+          "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1",
+              "from": "ansi-regex@^0.2.0",
+              "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "strip-ansi@^0.3.0",
+          "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1",
+              "from": "ansi-regex@^0.2.1",
+              "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@^0.2.0",
+          "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-0.2.0.tgz"
+        }
+      }
+    },
+    "fs-extra": {
+      "version": "0.12.0",
+      "from": "fs-extra@^0.12.0",
+      "resolved": "https://npm.webfilings.org/fs-extra/-/fs-extra-0.12.0.tgz",
+      "dependencies": {
+        "ncp": {
+          "version": "0.6.0",
+          "from": "ncp@^0.6.0",
+          "resolved": "https://npm.webfilings.org/ncp/-/ncp-0.6.0.tgz"
+        },
+        "jsonfile": {
+          "version": "2.0.0",
+          "from": "jsonfile@^2.0.0",
+          "resolved": "https://npm.webfilings.org/jsonfile/-/jsonfile-2.0.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.1",
+          "from": "rimraf@^2.2.8",
+          "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.3.1.tgz"
+        }
+      }
+    },
+    "fs-sync": {
+      "version": "0.2.5",
+      "from": "fs-sync@^0.2.5",
+      "resolved": "https://npm.webfilings.org/fs-sync/-/fs-sync-0.2.5.tgz",
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@~0.3.5",
+          "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@~0.2.10",
+          "resolved": "https://npm.webfilings.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+        },
+        "lodash": {
+          "version": "1.2.1",
+          "from": "lodash@~1.2.1",
+          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.2.1.tgz"
+        },
+        "glob": {
+          "version": "4.0.6",
+          "from": "glob@~4.0.4",
+          "resolved": "https://npm.webfilings.org/glob/-/glob-4.0.6.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@^3.0.2",
+              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "1.0.0",
+              "from": "minimatch@^1.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@^1.3.0",
+              "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@~2.1.4",
+          "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.1.4.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1",
+              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "4.5.1",
+      "from": "glob@^4.1.2",
+      "resolved": "https://npm.webfilings.org/glob/-/glob-4.5.1.tgz",
+      "dependencies": {
+        "inflight": {
+          "version": "1.0.4",
+          "from": "inflight@^1.0.4",
+          "resolved": "https://npm.webfilings.org/inflight/-/inflight-1.0.4.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@1",
+              "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        },
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2",
+          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.1",
+          "from": "minimatch@^2.0.1",
+          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@^1.0.0",
+              "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.1",
+          "from": "once@^1.3.0",
+          "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "wrappy@1",
+              "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp": {
+      "version": "3.8.11",
+      "from": "gulp@^3.8.7",
+      "resolved": "https://npm.webfilings.org/gulp/-/gulp-3.8.11.tgz",
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@^1.0.0",
+          "resolved": "https://npm.webfilings.org/archy/-/archy-1.0.0.tgz"
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "from": "deprecated@^0.0.1",
+          "resolved": "https://npm.webfilings.org/deprecated/-/deprecated-0.0.1.tgz"
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "interpret": {
+          "version": "0.3.10",
+          "from": "interpret@^0.3.2",
+          "resolved": "https://npm.webfilings.org/interpret/-/interpret-0.3.10.tgz"
+        },
+        "liftoff": {
+          "version": "2.0.2",
+          "from": "liftoff@^2.0.1",
+          "resolved": "https://npm.webfilings.org/liftoff/-/liftoff-2.0.2.tgz",
+          "dependencies": {
+            "extend": {
+              "version": "2.0.0",
+              "from": "extend@~2.0.0",
+              "resolved": "https://npm.webfilings.org/extend/-/extend-2.0.0.tgz"
+            },
+            "findup-sync": {
+              "version": "0.2.1",
+              "from": "findup-sync@~0.2.0",
+              "resolved": "https://npm.webfilings.org/findup-sync/-/findup-sync-0.2.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@~4.3.0",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@^1.0.4",
+                      "resolved": "https://npm.webfilings.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.1",
+                      "from": "minimatch@^2.0.1",
+                      "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@^0.2.0",
+                              "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@^1.3.0",
+                      "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "0.3.1",
+              "from": "flagged-respawn@~0.3.0",
+              "resolved": "https://npm.webfilings.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+            },
+            "resolve": {
+              "version": "1.1.5",
+              "from": "resolve@~1.1.0",
+              "resolved": "https://npm.webfilings.org/resolve/-/resolve-1.1.5.tgz"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.1.0",
+          "from": "minimist@^1.1.0",
+          "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+        },
+        "orchestrator": {
+          "version": "0.3.7",
+          "from": "orchestrator@^0.3.0",
+          "resolved": "https://npm.webfilings.org/orchestrator/-/orchestrator-0.3.7.tgz",
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "from": "end-of-stream@~0.1.5",
+              "resolved": "https://npm.webfilings.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@~1.3.0",
+                  "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "sequencify@~0.0.7",
+              "resolved": "https://npm.webfilings.org/sequencify/-/sequencify-0.0.7.tgz"
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "from": "stream-consume@~0.1.0",
+              "resolved": "https://npm.webfilings.org/stream-consume/-/stream-consume-0.1.0.tgz"
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "0.2.2",
+          "from": "pretty-hrtime@^0.2.0",
+          "resolved": "https://npm.webfilings.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz"
+        },
+        "semver": {
+          "version": "4.3.1",
+          "from": "semver@^4.1.0",
+          "resolved": "https://npm.webfilings.org/semver/-/semver-4.3.1.tgz"
+        },
+        "tildify": {
+          "version": "1.0.0",
+          "from": "tildify@^1.0.0",
+          "resolved": "https://npm.webfilings.org/tildify/-/tildify-1.0.0.tgz",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@^1.0.0",
+              "resolved": "https://npm.webfilings.org/user-home/-/user-home-1.1.1.tgz"
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.0.2",
+          "from": "v8flags@^2.0.2",
+          "resolved": "https://npm.webfilings.org/v8flags/-/v8flags-2.0.2.tgz"
+        },
+        "vinyl-fs": {
+          "version": "0.3.13",
+          "from": "vinyl-fs@^0.3.0",
+          "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.0",
+              "from": "defaults@^1.0.0",
+              "resolved": "https://npm.webfilings.org/defaults/-/defaults-1.0.0.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.1.19",
+                  "from": "clone@~0.1.5",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.1.19.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@^3.1.5",
+              "resolved": "https://npm.webfilings.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@^0.1.0",
+                  "resolved": "https://npm.webfilings.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@^0.0.12",
+                  "resolved": "https://npm.webfilings.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@^0.1.1",
+                      "resolved": "https://npm.webfilings.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@^0.0.6",
+              "resolved": "https://npm.webfilings.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@^0.5.1",
+                  "resolved": "https://npm.webfilings.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@~0.1.0",
+                      "resolved": "https://npm.webfilings.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@~1.0.1",
+                          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@~3.1.21",
+                          "resolved": "https://npm.webfilings.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1",
+                              "resolved": "https://npm.webfilings.org/inherits/-/inherits-1.0.0.tgz"
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@~1.2.0",
+                              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.11",
+                          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                            },
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@^3.0.0",
+              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@^1.0.0",
+              "resolved": "https://npm.webfilings.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.1",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-bump": {
+      "version": "0.1.13",
+      "from": "gulp-bump@^0.1.7",
+      "resolved": "https://npm.webfilings.org/gulp-bump/-/gulp-bump-0.1.13.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@^2.3.2",
+          "resolved": "https://npm.webfilings.org/semver/-/semver-2.3.2.tgz"
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@^0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@1.0.33",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@~3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-changed": {
+      "version": "1.1.1",
+      "from": "gulp-changed@^1.0.0",
+      "resolved": "https://npm.webfilings.org/gulp-changed/-/gulp-changed-1.1.1.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-coffee": {
+      "version": "2.3.1",
+      "from": "gulp-coffee@^2.0.1",
+      "resolved": "https://npm.webfilings.org/gulp-coffee/-/gulp-coffee-2.3.1.tgz",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.9.1",
+          "from": "coffee-script@^1.9.0",
+          "resolved": "https://npm.webfilings.org/coffee-script/-/coffee-script-1.9.1.tgz"
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "from": "merge@^1.2.0",
+          "resolved": "https://npm.webfilings.org/merge/-/merge-1.2.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.1",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@^0.1.4",
+          "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
+        }
+      }
+    },
+    "gulp-compass": {
+      "version": "1.3.3",
+      "from": "gulp-compass@^1.3.1",
+      "resolved": "https://npm.webfilings.org/gulp-compass/-/gulp-compass-1.3.3.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@^1.0.5",
+          "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.5.2",
+      "from": "gulp-concat@^2.3.5",
+      "resolved": "https://npm.webfilings.org/gulp-concat/-/gulp-concat-2.5.2.tgz",
+      "dependencies": {
+        "concat-with-sourcemaps": {
+          "version": "1.0.2",
+          "from": "concat-with-sourcemaps@^1.0.0",
+          "resolved": "https://npm.webfilings.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.2.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.1",
+              "from": "source-map@^0.4.0",
+              "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.4.1.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-connect": {
+      "version": "2.2.0",
+      "from": "gulp-connect@^2.0.5",
+      "resolved": "https://npm.webfilings.org/gulp-connect/-/gulp-connect-2.2.0.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.1.7",
+          "from": "event-stream@~3.1.0",
+          "resolved": "https://npm.webfilings.org/event-stream/-/event-stream-3.1.7.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.1",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@~0",
+              "resolved": "https://npm.webfilings.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@~0.1.0",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.2.10",
+              "from": "split@0.2",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@~0.0.4",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.3.2",
+          "from": "connect-livereload@~0.3.2",
+          "resolved": "https://npm.webfilings.org/connect-livereload/-/connect-livereload-0.3.2.tgz"
+        },
+        "connect": {
+          "version": "2.17.3",
+          "from": "connect@<2.18.0",
+          "resolved": "https://npm.webfilings.org/connect/-/connect-2.17.3.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://npm.webfilings.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.2.2",
+              "from": "body-parser@1.2.2",
+              "resolved": "https://npm.webfilings.org/body-parser/-/body-parser-1.2.2.tgz",
+              "dependencies": {
+                "raw-body": {
+                  "version": "1.1.6",
+                  "from": "raw-body@1.1.6",
+                  "resolved": "https://npm.webfilings.org/raw-body/-/raw-body-1.1.6.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://npm.webfilings.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://npm.webfilings.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.1.0",
+              "from": "cookie-parser@1.1.0",
+              "resolved": "https://npm.webfilings.org/cookie-parser/-/cookie-parser-1.1.0.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.3",
+              "from": "cookie-signature@1.0.3",
+              "resolved": "https://npm.webfilings.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+            },
+            "compression": {
+              "version": "1.0.2",
+              "from": "compression@1.0.2",
+              "resolved": "https://npm.webfilings.org/compression/-/compression-1.0.2.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.3.0",
+                  "from": "bytes@0.3.0",
+                  "resolved": "https://npm.webfilings.org/bytes/-/bytes-0.3.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.3",
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.3.tgz"
+                },
+                "compressible": {
+                  "version": "1.0.1",
+                  "from": "compressible@1.0.1",
+                  "resolved": "https://npm.webfilings.org/compressible/-/compressible-1.0.1.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.1.0",
+              "from": "connect-timeout@1.1.0",
+              "resolved": "https://npm.webfilings.org/connect-timeout/-/connect-timeout-1.1.0.tgz"
+            },
+            "csurf": {
+              "version": "1.2.0",
+              "from": "csurf@1.2.0",
+              "resolved": "https://npm.webfilings.org/csurf/-/csurf-1.2.0.tgz",
+              "dependencies": {
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "uid2@0.0.3",
+                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
+                },
+                "scmp": {
+                  "version": "0.0.3",
+                  "from": "scmp@~0.0.3",
+                  "resolved": "https://npm.webfilings.org/scmp/-/scmp-0.0.3.tgz"
+                }
+              }
+            },
+            "errorhandler": {
+              "version": "1.0.1",
+              "from": "errorhandler@1.0.1",
+              "resolved": "https://npm.webfilings.org/errorhandler/-/errorhandler-1.0.1.tgz"
+            },
+            "express-session": {
+              "version": "1.2.1",
+              "from": "express-session@1.2.1",
+              "resolved": "https://npm.webfilings.org/express-session/-/express-session-1.2.1.tgz",
+              "dependencies": {
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                },
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "uid2@0.0.3",
+                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
+                },
+                "buffer-crc32": {
+                  "version": "0.2.1",
+                  "from": "buffer-crc32@0.2.1",
+                  "resolved": "https://npm.webfilings.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.2",
+              "from": "fresh@0.2.2",
+              "resolved": "https://npm.webfilings.org/fresh/-/fresh-0.2.2.tgz"
+            },
+            "method-override": {
+              "version": "1.0.2",
+              "from": "method-override@1.0.2",
+              "resolved": "https://npm.webfilings.org/method-override/-/method-override-1.0.2.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.0.0",
+                  "from": "methods@1.0.0",
+                  "resolved": "https://npm.webfilings.org/methods/-/methods-1.0.0.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.1.1",
+              "from": "morgan@1.1.1",
+              "resolved": "https://npm.webfilings.org/morgan/-/morgan-1.1.1.tgz"
+            },
+            "on-headers": {
+              "version": "0.0.0",
+              "from": "on-headers@0.0.0",
+              "resolved": "https://npm.webfilings.org/on-headers/-/on-headers-0.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.0.1",
+              "from": "parseurl@1.0.1",
+              "resolved": "https://npm.webfilings.org/parseurl/-/parseurl-1.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@0.6.6",
+              "resolved": "https://npm.webfilings.org/qs/-/qs-0.6.6.tgz"
+            },
+            "response-time": {
+              "version": "1.0.0",
+              "from": "response-time@1.0.0",
+              "resolved": "https://npm.webfilings.org/response-time/-/response-time-1.0.0.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.0.0",
+              "from": "serve-favicon@2.0.0",
+              "resolved": "https://npm.webfilings.org/serve-favicon/-/serve-favicon-2.0.0.tgz"
+            },
+            "serve-index": {
+              "version": "1.0.3",
+              "from": "serve-index@1.0.3",
+              "resolved": "https://npm.webfilings.org/serve-index/-/serve-index-1.0.3.tgz",
+              "dependencies": {
+                "batch": {
+                  "version": "0.5.0",
+                  "from": "batch@0.5.0",
+                  "resolved": "https://npm.webfilings.org/batch/-/batch-0.5.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.3",
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.3.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.1.0",
+              "from": "serve-static@1.1.0",
+              "resolved": "https://npm.webfilings.org/serve-static/-/serve-static-1.1.0.tgz",
+              "dependencies": {
+                "send": {
+                  "version": "0.3.0",
+                  "from": "send@0.3.0",
+                  "resolved": "https://npm.webfilings.org/send/-/send-0.3.0.tgz",
+                  "dependencies": {
+                    "buffer-crc32": {
+                      "version": "0.2.1",
+                      "from": "buffer-crc32@0.2.1",
+                      "resolved": "https://npm.webfilings.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.8.0",
+                      "from": "debug@0.8.0",
+                      "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.0.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@1.2.11",
+                      "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/range-parser/-/range-parser-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.2.0",
+              "from": "type-is@1.2.0",
+              "resolved": "https://npm.webfilings.org/type-is/-/type-is-1.2.0.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@1.2.11",
+                  "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                }
+              }
+            },
+            "vhost": {
+              "version": "1.0.0",
+              "from": "vhost@1.0.0",
+              "resolved": "https://npm.webfilings.org/vhost/-/vhost-1.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://npm.webfilings.org/pause/-/pause-0.0.1.tgz"
+            },
+            "debug": {
+              "version": "0.8.1",
+              "from": "debug@>= 0.8.0 < 1",
+              "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.1.tgz"
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "from": "multiparty@2.2.0",
+              "resolved": "https://npm.webfilings.org/multiparty/-/multiparty-2.2.0.tgz",
+              "dependencies": {
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@~0.2.0",
+                  "resolved": "https://npm.webfilings.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.10",
+                  "from": "readable-stream@~1.1.9",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "debuglog": {
+                      "version": "0.0.2",
+                      "from": "debuglog@0.0.2",
+                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-flatten": {
+      "version": "0.0.4",
+      "from": "gulp-flatten@^0.0.4",
+      "resolved": "https://npm.webfilings.org/gulp-flatten/-/gulp-flatten-0.0.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-header": {
+      "version": "1.2.2",
+      "from": "gulp-header@^1.0.5",
+      "resolved": "https://npm.webfilings.org/gulp-header/-/gulp-header-1.2.2.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@*",
+          "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@>=0.6.1 <1.0.0-0",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-istanbul": {
+      "version": "0.3.1",
+      "from": "gulp-istanbul@^0.3.1",
+      "resolved": "https://npm.webfilings.org/gulp-istanbul/-/gulp-istanbul-0.3.1.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "istanbul": {
+          "version": "0.3.7",
+          "from": "istanbul@^0.3.2",
+          "resolved": "https://npm.webfilings.org/istanbul/-/istanbul-0.3.7.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "2.0.0",
+              "from": "esprima@2.0.x",
+              "resolved": "https://npm.webfilings.org/esprima/-/esprima-2.0.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.3.3",
+              "from": "escodegen@1.3.x",
+              "resolved": "https://npm.webfilings.org/escodegen/-/escodegen-1.3.3.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.0.0",
+                  "from": "esutils@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.1.1",
+                  "from": "esprima@~1.1.1",
+                  "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.1.1.tgz"
+                }
+              }
+            },
+            "handlebars": {
+              "version": "1.3.0",
+              "from": "handlebars@1.3.x",
+              "resolved": "https://npm.webfilings.org/handlebars/-/handlebars-1.3.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@~0.3",
+                  "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz"
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@~2.3",
+                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@~0.2.6",
+                      "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@3.x",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@0.1.x",
+              "resolved": "https://npm.webfilings.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "0.4.0",
+                  "from": "minimatch@0.x",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.4.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@3.x",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@1.0.x",
+              "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@0.9.x",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "from": "supports-color@1.2.x",
+              "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.2.1.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@1.0.x",
+              "resolved": "https://npm.webfilings.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.x",
+              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "from": "resolve@0.7.x",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@3.x",
+              "resolved": "https://npm.webfilings.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.1",
+                  "from": "argparse@~ 1.0.0",
+                  "resolved": "https://npm.webfilings.org/argparse/-/argparse-1.0.1.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.2.0",
+                      "from": "lodash@~3.2",
+                      "resolved": "https://npm.webfilings.org/lodash/-/lodash-3.2.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@~1.0.2",
+                      "resolved": "https://npm.webfilings.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@1.x",
+              "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@^0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@1.0.33",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@~2.1.1",
+              "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@~0.4.0",
+                  "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-jasmine": {
+      "version": "1.0.1",
+      "from": "gulp-jasmine@^1.0.1",
+      "resolved": "https://npm.webfilings.org/gulp-jasmine/-/gulp-jasmine-1.0.1.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minijasminenode2": {
+          "version": "1.0.0",
+          "from": "minijasminenode2@^1.0.0",
+          "resolved": "https://npm.webfilings.org/minijasminenode2/-/minijasminenode2-1.0.0.tgz",
+          "dependencies": {
+            "jasmine-core": {
+              "version": "2.0.0",
+              "from": "jasmine-core@2.0.0",
+              "resolved": "https://npm.webfilings.org/jasmine-core/-/jasmine-core-2.0.0.tgz"
+            }
+          }
+        },
+        "require-uncached": {
+          "version": "1.0.2",
+          "from": "require-uncached@^1.0.2",
+          "resolved": "https://npm.webfilings.org/require-uncached/-/require-uncached-1.0.2.tgz",
+          "dependencies": {
+            "caller-path": {
+              "version": "0.1.0",
+              "from": "caller-path@^0.1.0",
+              "resolved": "https://npm.webfilings.org/caller-path/-/caller-path-0.1.0.tgz",
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "from": "callsites@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/callsites/-/callsites-0.2.0.tgz"
+                }
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.0",
+              "from": "resolve-from@^1.0.0",
+              "resolved": "https://npm.webfilings.org/resolve-from/-/resolve-from-1.0.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-jsdoc": {
+      "version": "0.1.4",
+      "from": "gulp-jsdoc@^0.1.4",
+      "resolved": "https://npm.webfilings.org/gulp-jsdoc/-/gulp-jsdoc-0.1.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@~0.4.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.17",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@~2.1.1",
+              "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@~0.4.0",
+                  "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@~0.4.0",
+          "resolved": "https://npm.webfilings.org/chalk/-/chalk-0.4.0.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.7",
+              "from": "has-color@~0.1.0",
+              "resolved": "https://npm.webfilings.org/has-color/-/has-color-0.1.7.tgz"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "ansi-styles@~1.0.0",
+              "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "strip-ansi@~0.1.0",
+              "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@~0.2.0",
+          "resolved": "https://npm.webfilings.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "vinyl-fs": {
+          "version": "0.1.4",
+          "from": "vinyl-fs@~0.1.2",
+          "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.1.4.tgz",
+          "dependencies": {
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@^0.2.0",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@~0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@^3.1.5",
+              "resolved": "https://npm.webfilings.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@^0.1.0",
+                  "resolved": "https://npm.webfilings.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@^0.0.12",
+                  "resolved": "https://npm.webfilings.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@^0.1.1",
+                      "resolved": "https://npm.webfilings.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                },
+                "through2": {
+                  "version": "0.6.3",
+                  "from": "through2@^0.6.1",
+                  "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@^0.0.6",
+              "resolved": "https://npm.webfilings.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@^0.5.1",
+                  "resolved": "https://npm.webfilings.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@~0.1.0",
+                      "resolved": "https://npm.webfilings.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@~1.0.1",
+                          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@~3.1.21",
+                          "resolved": "https://npm.webfilings.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1",
+                              "resolved": "https://npm.webfilings.org/inherits/-/inherits-1.0.0.tgz"
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@~1.2.0",
+                              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.11",
+                          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                            },
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@^0.3.5",
+              "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@^2.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@^0.1.0",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+            }
+          }
+        },
+        "jsdoc": {
+          "version": "3.3.0-alpha5",
+          "from": "jsdoc@3.3.0-alpha5",
+          "resolved": "https://npm.webfilings.org/jsdoc/-/jsdoc-3.3.0-alpha5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@~0.1.22",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.1.22.tgz"
+            },
+            "catharsis": {
+              "version": "0.7.1",
+              "from": "catharsis@~0.7.0",
+              "resolved": "https://npm.webfilings.org/catharsis/-/catharsis-0.7.1.tgz"
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~1.0.4",
+              "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "js2xmlparser": {
+              "version": "0.1.9",
+              "from": "js2xmlparser@~0.1.0",
+              "resolved": "https://npm.webfilings.org/js2xmlparser/-/js2xmlparser-0.1.9.tgz"
+            },
+            "taffydb": {
+              "version": "2.6.2",
+              "from": "https://github.com/hegemonic/taffydb/tarball/master",
+              "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@~1.4.2",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "wrench": {
+              "version": "1.3.9",
+              "from": "wrench@~1.3.9",
+              "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.3.9.tgz"
+            }
+          }
+        },
+        "taffydb": {
+          "version": "2.7.2",
+          "from": "taffydb@~2.7.2",
+          "resolved": "https://npm.webfilings.org/taffydb/-/taffydb-2.7.2.tgz"
+        },
+        "ink-docstrap": {
+          "version": "0.3.0-0",
+          "from": "ink-docstrap@~0.3.0-0",
+          "resolved": "https://npm.webfilings.org/ink-docstrap/-/ink-docstrap-0.3.0-0.tgz"
+        },
+        "wrench": {
+          "version": "1.5.8",
+          "from": "wrench@~1.5.6",
+          "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.5.8.tgz"
+        },
+        "marked": {
+          "version": "0.3.3",
+          "from": "marked@~0.3.1",
+          "resolved": "https://npm.webfilings.org/marked/-/marked-0.3.3.tgz"
+        }
+      }
+    },
+    "gulp-jshint": {
+      "version": "1.9.2",
+      "from": "gulp-jshint@^1.5.5",
+      "resolved": "https://npm.webfilings.org/gulp-jshint/-/gulp-jshint-1.9.2.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.5.0",
+          "from": "lodash@^3.0.1",
+          "resolved": "https://npm.webfilings.org/lodash/-/lodash-3.5.0.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.1",
+          "from": "minimatch@^2.0.1",
+          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@^1.0.0",
+              "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rcloader": {
+          "version": "0.1.2",
+          "from": "rcloader@0.1.2",
+          "resolved": "https://npm.webfilings.org/rcloader/-/rcloader-0.1.2.tgz",
+          "dependencies": {
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "rcfinder@~0.1.6",
+              "resolved": "https://npm.webfilings.org/rcfinder/-/rcfinder-0.1.8.tgz"
+            },
+            "lodash": {
+              "version": "2.4.1",
+              "from": "lodash@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash/-/lodash-2.4.1.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-karma": {
+      "version": "0.0.4",
+      "from": "gulp-karma@0.0.4",
+      "resolved": "https://npm.webfilings.org/gulp-karma/-/gulp-karma-0.0.4.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@~0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@~0.0.1",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "from": "xtend@~2.1.1",
+          "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+          "dependencies": {
+            "object-keys": {
+              "version": "0.4.0",
+              "from": "object-keys@~0.4.0",
+              "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+            }
+          }
+        },
+        "event-stream": {
+          "version": "3.0.20",
+          "from": "event-stream@~3.0.20",
+          "resolved": "https://npm.webfilings.org/event-stream/-/event-stream-3.0.20.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.1",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@~0",
+              "resolved": "https://npm.webfilings.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.0.5",
+              "from": "map-stream@~0.0.3",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.0.5.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.2.10",
+              "from": "split@0.2",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@~0.0.3",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-livereload": {
+      "version": "2.1.0",
+      "from": "gulp-livereload@2.1.0",
+      "resolved": "https://npm.webfilings.org/gulp-livereload/-/gulp-livereload-2.1.0.tgz",
+      "dependencies": {
+        "lodash.merge": {
+          "version": "2.4.1",
+          "from": "lodash.merge@^2.4.1",
+          "resolved": "https://npm.webfilings.org/lodash.merge/-/lodash.merge-2.4.1.tgz",
+          "dependencies": {
+            "lodash._basecreatecallback": {
+              "version": "2.4.1",
+              "from": "lodash._basecreatecallback@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz",
+              "dependencies": {
+                "lodash.bind": {
+                  "version": "2.4.1",
+                  "from": "lodash.bind@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.bind/-/lodash.bind-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._createwrapper": {
+                      "version": "2.4.1",
+                      "from": "lodash._createwrapper@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._basebind": {
+                          "version": "2.4.1",
+                          "from": "lodash._basebind@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash._basebind/-/lodash._basebind-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "lodash._basecreate@~2.4.1",
+                              "resolved": "https://npm.webfilings.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@~2.4.1",
+                                  "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@~2.4.1",
+                                  "resolved": "https://npm.webfilings.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash._basecreatewrapper": {
+                          "version": "2.4.1",
+                          "from": "lodash._basecreatewrapper@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._basecreate": {
+                              "version": "2.4.1",
+                              "from": "lodash._basecreate@~2.4.1",
+                              "resolved": "https://npm.webfilings.org/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz",
+                              "dependencies": {
+                                "lodash._isnative": {
+                                  "version": "2.4.1",
+                                  "from": "lodash._isnative@~2.4.1",
+                                  "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                                },
+                                "lodash.noop": {
+                                  "version": "2.4.1",
+                                  "from": "lodash.noop@~2.4.1",
+                                  "resolved": "https://npm.webfilings.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "from": "lodash.isfunction@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.identity": {
+                  "version": "2.4.1",
+                  "from": "lodash.identity@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.identity/-/lodash.identity-2.4.1.tgz"
+                },
+                "lodash._setbinddata": {
+                  "version": "2.4.1",
+                  "from": "lodash._setbinddata@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.noop": {
+                      "version": "2.4.1",
+                      "from": "lodash.noop@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash.noop/-/lodash.noop-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.support": {
+                  "version": "2.4.1",
+                  "from": "lodash.support@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.support/-/lodash.support-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._basemerge": {
+              "version": "2.4.1",
+              "from": "lodash._basemerge@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._basemerge/-/lodash._basemerge-2.4.1.tgz",
+              "dependencies": {
+                "lodash.foreach": {
+                  "version": "2.4.1",
+                  "from": "lodash.foreach@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.foreach/-/lodash.foreach-2.4.1.tgz"
+                },
+                "lodash.forown": {
+                  "version": "2.4.1",
+                  "from": "lodash.forown@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.forown/-/lodash.forown-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "from": "lodash.keys@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "from": "lodash._shimkeys@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isarray": {
+                  "version": "2.4.1",
+                  "from": "lodash.isarray@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.isplainobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isplainobject@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.isplainobject/-/lodash.isplainobject-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash._shimisplainobject": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimisplainobject@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._shimisplainobject/-/lodash._shimisplainobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash.forin": {
+                          "version": "2.4.1",
+                          "from": "lodash.forin@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash.forin/-/lodash.forin-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "from": "lodash._objecttypes@~2.4.1",
+                              "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash.isfunction": {
+                          "version": "2.4.1",
+                          "from": "lodash.isfunction@~2.4.1",
+                          "resolved": "https://npm.webfilings.org/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._getarray": {
+              "version": "2.4.1",
+              "from": "lodash._getarray@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._getarray/-/lodash._getarray-2.4.1.tgz",
+              "dependencies": {
+                "lodash._arraypool": {
+                  "version": "2.4.1",
+                  "from": "lodash._arraypool@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash.isobject": {
+              "version": "2.4.1",
+              "from": "lodash.isobject@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+              "dependencies": {
+                "lodash._objecttypes": {
+                  "version": "2.4.1",
+                  "from": "lodash._objecttypes@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._releasearray": {
+              "version": "2.4.1",
+              "from": "lodash._releasearray@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz",
+              "dependencies": {
+                "lodash._arraypool": {
+                  "version": "2.4.1",
+                  "from": "lodash._arraypool@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz"
+                },
+                "lodash._maxpoolsize": {
+                  "version": "2.4.1",
+                  "from": "lodash._maxpoolsize@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash._slice": {
+              "version": "2.4.1",
+              "from": "lodash._slice@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._slice/-/lodash._slice-2.4.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-livescript": {
+      "version": "2.3.0",
+      "from": "gulp-livescript@^2.0.0",
+      "resolved": "https://npm.webfilings.org/gulp-livescript/-/gulp-livescript-2.3.0.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-minify-css": {
+      "version": "0.3.13",
+      "from": "gulp-minify-css@^0.3.8",
+      "resolved": "https://npm.webfilings.org/gulp-minify-css/-/gulp-minify-css-0.3.13.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "clean-css": {
+          "version": "3.0.10",
+          "from": "clean-css@~3.0.4",
+          "resolved": "https://npm.webfilings.org/clean-css/-/clean-css-3.0.10.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.5.1",
+              "from": "commander@2.5.x",
+              "resolved": "https://npm.webfilings.org/commander/-/commander-2.5.1.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.1",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "bufferstreams": {
+          "version": "0.0.2",
+          "from": "bufferstreams@0.0.2",
+          "resolved": "https://npm.webfilings.org/bufferstreams/-/bufferstreams-0.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.10",
+              "from": "readable-stream@^1.0.26-2",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "debuglog": {
+                  "version": "0.0.2",
+                  "from": "debuglog@0.0.2",
+                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "memory-cache": {
+          "version": "0.0.5",
+          "from": "memory-cache@0.0.5",
+          "resolved": "https://npm.webfilings.org/memory-cache/-/memory-cache-0.0.5.tgz"
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@^0.1.4",
+          "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
+        }
+      }
+    },
+    "gulp-open": {
+      "version": "0.3.2",
+      "from": "gulp-open@^0.3.0",
+      "resolved": "https://npm.webfilings.org/gulp-open/-/gulp-open-0.3.2.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-plato": {
+      "version": "1.0.2",
+      "from": "gulp-plato@^1.0.1",
+      "resolved": "https://npm.webfilings.org/gulp-plato/-/gulp-plato-1.0.2.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "plato": {
+          "version": "1.4.0",
+          "from": "plato@^1.1.0",
+          "resolved": "https://npm.webfilings.org/plato/-/plato-1.4.0.tgz",
+          "dependencies": {
+            "escomplex-js": {
+              "version": "1.2.0",
+              "from": "escomplex-js@~1.2.0",
+              "resolved": "https://npm.webfilings.org/escomplex-js/-/escomplex-js-1.2.0.tgz",
+              "dependencies": {
+                "check-types": {
+                  "version": "2.1.1",
+                  "from": "check-types@2.1.x",
+                  "resolved": "https://npm.webfilings.org/check-types/-/check-types-2.1.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "esprima@1.0.x",
+                  "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
+                },
+                "escomplex-ast-moz": {
+                  "version": "0.1.6",
+                  "from": "escomplex-ast-moz@0.1.6",
+                  "resolved": "https://npm.webfilings.org/escomplex-ast-moz/-/escomplex-ast-moz-0.1.6.tgz",
+                  "dependencies": {
+                    "escomplex-traits": {
+                      "version": "0.2.0",
+                      "from": "escomplex-traits@0.2.x",
+                      "resolved": "https://npm.webfilings.org/escomplex-traits/-/escomplex-traits-0.2.0.tgz"
+                    }
+                  }
+                },
+                "escomplex": {
+                  "version": "1.2.0",
+                  "from": "escomplex@1.2.0",
+                  "resolved": "https://npm.webfilings.org/escomplex/-/escomplex-1.2.0.tgz",
+                  "dependencies": {
+                    "matrix-utilities": {
+                      "version": "1.2.4",
+                      "from": "matrix-utilities@1.2.x",
+                      "resolved": "https://npm.webfilings.org/matrix-utilities/-/matrix-utilities-1.2.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fs-extra": {
+              "version": "0.3.2",
+              "from": "fs-extra@^0.3.2",
+              "resolved": "https://npm.webfilings.org/fs-extra/-/fs-extra-0.3.2.tgz",
+              "dependencies": {
+                "rimraf": {
+                  "version": "2.0.3",
+                  "from": "rimraf@~2.0.2",
+                  "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.0.3.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.1.14",
+                      "from": "graceful-fs@~1.1",
+                      "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.1.14.tgz"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.2.7",
+                  "from": "ncp@0.2.x",
+                  "resolved": "https://npm.webfilings.org/ncp/-/ncp-0.2.7.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@0.3.x",
+                  "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                },
+                "jsonfile": {
+                  "version": "0.0.1",
+                  "from": "jsonfile@0.0.x",
+                  "resolved": "https://npm.webfilings.org/jsonfile/-/jsonfile-0.0.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.4.2",
+              "from": "glob@~4.4.1",
+              "resolved": "https://npm.webfilings.org/glob/-/glob-4.4.2.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@^1.0.4",
+                  "resolved": "https://npm.webfilings.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.1",
+                  "from": "once@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1",
+                      "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.5.0",
+              "from": "lodash@^3.3.1",
+              "resolved": "https://npm.webfilings.org/lodash/-/lodash-3.5.0.tgz"
+            },
+            "posix-getopt": {
+              "version": "1.1.0",
+              "from": "posix-getopt@~1.1.0",
+              "resolved": "https://npm.webfilings.org/posix-getopt/-/posix-getopt-1.1.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-plumber": {
+      "version": "0.6.6",
+      "from": "gulp-plumber@^0.6.2",
+      "resolved": "https://npm.webfilings.org/gulp-plumber/-/gulp-plumber-0.6.6.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-react": {
+      "version": "2.1.0",
+      "from": "gulp-react@^2.0.0",
+      "resolved": "https://npm.webfilings.org/gulp-react/-/gulp-react-2.1.0.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@>=3.0.0 <4.0.0-0",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@^2.0.0",
+          "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "react-tools": {
+          "version": "0.13.0-rc2",
+          "from": "react-tools@^0.13.0-rc1",
+          "resolved": "https://npm.webfilings.org/react-tools/-/react-tools-0.13.0-rc2.tgz",
+          "dependencies": {
+            "commoner": {
+              "version": "0.10.1",
+              "from": "commoner@^0.10.0",
+              "resolved": "https://npm.webfilings.org/commoner/-/commoner-0.10.1.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "1.1.2",
+                  "from": "q@~1.1.2",
+                  "resolved": "https://npm.webfilings.org/q/-/q-1.1.2.tgz"
+                },
+                "recast": {
+                  "version": "0.9.18",
+                  "from": "recast@~0.9.5",
+                  "resolved": "https://npm.webfilings.org/recast/-/recast-0.9.18.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "10001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@~10001.1.0-dev-harmony-fb",
+                      "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "ast-types": {
+                      "version": "0.6.16",
+                      "from": "ast-types@~0.6.1",
+                      "resolved": "https://npm.webfilings.org/ast-types/-/ast-types-0.6.16.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.5.1",
+                  "from": "commander@~2.5.0",
+                  "resolved": "https://npm.webfilings.org/commander/-/commander-2.5.1.tgz"
+                },
+                "graceful-fs": {
+                  "version": "3.0.5",
+                  "from": "graceful-fs@~3.0.4",
+                  "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                },
+                "glob": {
+                  "version": "4.2.2",
+                  "from": "glob@~4.2.1",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-4.2.2.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@^1.0.4",
+                      "resolved": "https://npm.webfilings.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "from": "minimatch@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@^1.3.0",
+                      "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@~0.1.6",
+                  "resolved": "https://npm.webfilings.org/private/-/private-0.1.6.tgz"
+                },
+                "install": {
+                  "version": "0.1.8",
+                  "from": "install@~0.1.7",
+                  "resolved": "https://npm.webfilings.org/install/-/install-0.1.8.tgz"
+                },
+                "iconv-lite": {
+                  "version": "0.4.7",
+                  "from": "iconv-lite@~0.4.5",
+                  "resolved": "https://npm.webfilings.org/iconv-lite/-/iconv-lite-0.4.7.tgz"
+                }
+              }
+            },
+            "jstransform": {
+              "version": "10.1.0",
+              "from": "jstransform@^10.0.0",
+              "resolved": "https://npm.webfilings.org/jstransform/-/jstransform-10.1.0.tgz",
+              "dependencies": {
+                "base62": {
+                  "version": "0.1.1",
+                  "from": "base62@0.1.1",
+                  "resolved": "https://npm.webfilings.org/base62/-/base62-0.1.1.tgz"
+                },
+                "esprima-fb": {
+                  "version": "13001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+                  "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.31",
+                  "from": "source-map@0.1.31",
+                  "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.31.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
+          "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
+        }
+      }
+    },
+    "gulp-rename": {
+      "version": "1.2.0",
+      "from": "gulp-rename@^1.2.0",
+      "resolved": "https://npm.webfilings.org/gulp-rename/-/gulp-rename-1.2.0.tgz"
+    },
+    "gulp-sass": {
+      "version": "0.7.3",
+      "from": "gulp-sass@^0.7.2",
+      "resolved": "https://npm.webfilings.org/gulp-sass/-/gulp-sass-0.7.3.tgz",
+      "dependencies": {
+        "node-sass": {
+          "version": "0.9.6",
+          "from": "node-sass@^0.9",
+          "resolved": "https://npm.webfilings.org/node-sass/-/node-sass-0.9.6.tgz",
+          "dependencies": {
+            "nan": {
+              "version": "1.3.0",
+              "from": "nan@~1.3.0",
+              "resolved": "https://npm.webfilings.org/nan/-/nan-1.3.0.tgz"
+            },
+            "node-watch": {
+              "version": "0.3.4",
+              "from": "node-watch@~0.3.4",
+              "resolved": "https://npm.webfilings.org/node-watch/-/node-watch-0.3.4.tgz"
+            },
+            "object-assign": {
+              "version": "1.0.0",
+              "from": "object-assign@~1.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-1.0.0.tgz"
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@~0.3.0",
+              "resolved": "https://npm.webfilings.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "sinon": {
+              "version": "1.10.3",
+              "from": "sinon@~1.10.3",
+              "resolved": "https://npm.webfilings.org/sinon/-/sinon-1.10.3.tgz",
+              "dependencies": {
+                "formatio": {
+                  "version": "1.0.2",
+                  "from": "formatio@~1.0",
+                  "resolved": "https://npm.webfilings.org/formatio/-/formatio-1.0.2.tgz",
+                  "dependencies": {
+                    "samsam": {
+                      "version": "1.1.2",
+                      "from": "samsam@~1.1",
+                      "resolved": "https://npm.webfilings.org/samsam/-/samsam-1.1.2.tgz"
+                    }
+                  }
+                },
+                "util": {
+                  "version": "0.10.3",
+                  "from": "util@>=0.10.3 <1",
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "node-sass-middleware": {
+              "version": "0.3.1",
+              "from": "node-sass-middleware@~0.3.0",
+              "resolved": "https://npm.webfilings.org/node-sass-middleware/-/node-sass-middleware-0.3.1.tgz"
+            },
+            "get-stdin": {
+              "version": "3.0.2",
+              "from": "get-stdin@~3.0.0",
+              "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-3.0.2.tgz"
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "map-stream@~0.1",
+          "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+        }
+      }
+    },
+    "gulp-shell": {
+      "version": "0.2.11",
+      "from": "gulp-shell@^0.2.8",
+      "resolved": "https://npm.webfilings.org/gulp-shell/-/gulp-shell-0.2.11.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@~0.9.0",
+          "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-tap": {
+      "version": "0.1.3",
+      "from": "gulp-tap@^0.1.1",
+      "resolved": "https://npm.webfilings.org/gulp-tap/-/gulp-tap-0.1.3.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.1.7",
+          "from": "event-stream@~3.1.0",
+          "resolved": "https://npm.webfilings.org/event-stream/-/event-stream-3.1.7.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.1",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@~0",
+              "resolved": "https://npm.webfilings.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@~0.1.0",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.2.10",
+              "from": "split@0.2",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@~0.0.3",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-tsc": {
+      "version": "0.9.2",
+      "from": "gulp-tsc@^0.9.0",
+      "resolved": "https://npm.webfilings.org/gulp-tsc/-/gulp-tsc-0.9.2.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.0",
+          "from": "async@^0.9.0",
+          "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+        },
+        "through2": {
+          "version": "1.1.1",
+          "from": "through2@^1.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@^1.0.5",
+          "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+        },
+        "temp": {
+          "version": "0.8.1",
+          "from": "temp@^0.8.0",
+          "resolved": "https://npm.webfilings.org/temp/-/temp-0.8.1.tgz",
+          "dependencies": {
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.6",
+              "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.13",
+          "from": "vinyl-fs@^0.3.4",
+          "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.0",
+              "from": "defaults@^1.0.0",
+              "resolved": "https://npm.webfilings.org/defaults/-/defaults-1.0.0.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.1.19",
+                  "from": "clone@~0.1.5",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.1.19.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@^3.1.5",
+              "resolved": "https://npm.webfilings.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@^0.1.0",
+                  "resolved": "https://npm.webfilings.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@^0.0.12",
+                  "resolved": "https://npm.webfilings.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@^0.1.1",
+                      "resolved": "https://npm.webfilings.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@^0.0.6",
+              "resolved": "https://npm.webfilings.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@^0.5.1",
+                  "resolved": "https://npm.webfilings.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@~0.1.0",
+                      "resolved": "https://npm.webfilings.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@~1.0.1",
+                          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@~3.1.21",
+                          "resolved": "https://npm.webfilings.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1",
+                              "resolved": "https://npm.webfilings.org/inherits/-/inherits-1.0.0.tgz"
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@~1.2.0",
+                              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.11",
+                          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                            },
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@^3.0.0",
+              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@^1.0.0",
+              "resolved": "https://npm.webfilings.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.1",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.3.1",
+          "from": "rimraf@^2.2.6",
+          "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.3.1.tgz"
+        },
+        "resolve": {
+          "version": "0.7.4",
+          "from": "resolve@^0.7.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+        }
+      }
+    },
+    "gulp-tslint": {
+      "version": "1.4.3",
+      "from": "gulp-tslint@^1.1.0",
+      "resolved": "https://npm.webfilings.org/gulp-tslint/-/gulp-tslint-1.4.3.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "map-stream@~0.1.0",
+          "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+        },
+        "rcloader": {
+          "version": "0.1.4",
+          "from": "rcloader@~0.1.4",
+          "resolved": "https://npm.webfilings.org/rcloader/-/rcloader-0.1.4.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "3.5.0",
+              "from": "lodash@^3.0.1",
+              "resolved": "https://npm.webfilings.org/lodash/-/lodash-3.5.0.tgz"
+            },
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "rcfinder@^0.1.6",
+              "resolved": "https://npm.webfilings.org/rcfinder/-/rcfinder-0.1.8.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.1",
+                  "from": "lodash@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash/-/lodash-2.4.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.6",
+          "from": "through@~2.3.6",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+        },
+        "tslint": {
+          "version": "2.1.1",
+          "from": "tslint@^2.1.0",
+          "resolved": "https://npm.webfilings.org/tslint/-/tslint-2.1.1.tgz",
+          "dependencies": {
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@~0.1.2",
+              "resolved": "https://npm.webfilings.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~3.2.9",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@~0.6.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.1",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@~2.3.3",
+              "resolved": "https://npm.webfilings.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-uglify": {
+      "version": "1.1.0",
+      "from": "gulp-uglify@^1.0.1",
+      "resolved": "https://npm.webfilings.org/gulp-uglify/-/gulp-uglify-1.1.0.tgz",
+      "dependencies": {
+        "deepmerge": {
+          "version": "0.2.7",
+          "from": "deepmerge@>=0.2.7 <0.3.0-0",
+          "resolved": "https://npm.webfilings.org/deepmerge/-/deepmerge-0.2.7.tgz"
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.2",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@~0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.10",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "debuglog": {
+                          "version": "0.0.2",
+                          "from": "debuglog@0.0.2",
+                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.1",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.16",
+          "from": "uglify-js@2.4.16",
+          "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.6",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@~0.3.5",
+              "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@~1.0.0",
+              "resolved": "https://npm.webfilings.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@^0.1.4",
+          "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "2.2.20",
+      "from": "gulp-util@^2.2.19",
+      "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-2.2.20.tgz",
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@^1.0.11",
+          "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@*",
+              "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@*",
+              "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@^1.0.1",
+                      "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.0",
+                      "from": "map-obj@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.0",
+                          "from": "is-finite@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.0",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@^2.0.0",
+                  "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash._reinterpolate": {
+          "version": "2.4.1",
+          "from": "lodash._reinterpolate@^2.4.1",
+          "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+        },
+        "lodash.template": {
+          "version": "2.4.1",
+          "from": "lodash.template@^2.4.1",
+          "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-2.4.1.tgz",
+          "dependencies": {
+            "lodash.defaults": {
+              "version": "2.4.1",
+              "from": "lodash.defaults@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+              "dependencies": {
+                "lodash._objecttypes": {
+                  "version": "2.4.1",
+                  "from": "lodash._objecttypes@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                }
+              }
+            },
+            "lodash.escape": {
+              "version": "2.4.1",
+              "from": "lodash.escape@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+              "dependencies": {
+                "lodash._escapehtmlchar": {
+                  "version": "2.4.1",
+                  "from": "lodash._escapehtmlchar@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._htmlescapes": {
+                      "version": "2.4.1",
+                      "from": "lodash._htmlescapes@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._reunescapedhtml": {
+                  "version": "2.4.1",
+                  "from": "lodash._reunescapedhtml@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._htmlescapes": {
+                      "version": "2.4.1",
+                      "from": "lodash._htmlescapes@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._escapestringchar": {
+              "version": "2.4.1",
+              "from": "lodash._escapestringchar@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+            },
+            "lodash.keys": {
+              "version": "2.4.1",
+              "from": "lodash.keys@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+              "dependencies": {
+                "lodash._isnative": {
+                  "version": "2.4.1",
+                  "from": "lodash._isnative@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                },
+                "lodash.isobject": {
+                  "version": "2.4.1",
+                  "from": "lodash.isobject@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash._shimkeys": {
+                  "version": "2.4.1",
+                  "from": "lodash._shimkeys@~2.4.1",
+                  "resolved": "https://npm.webfilings.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@~2.4.1",
+                      "resolved": "https://npm.webfilings.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.templatesettings": {
+              "version": "2.4.1",
+              "from": "lodash.templatesettings@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+            },
+            "lodash.values": {
+              "version": "2.4.1",
+              "from": "lodash.values@~2.4.1",
+              "resolved": "https://npm.webfilings.org/lodash.values/-/lodash.values-2.4.1.tgz"
+            }
+          }
+        },
+        "minimist": {
+          "version": "0.2.0",
+          "from": "minimist@^0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "from": "multipipe@^0.1.0",
+          "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "duplexer2@0.0.2",
+              "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.10",
+                  "from": "readable-stream@~1.1.9",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "debuglog": {
+                      "version": "0.0.2",
+                      "from": "debuglog@0.0.2",
+                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@^0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@1.0.33",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@~3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            }
+          }
+        },
+        "vinyl": {
+          "version": "0.2.3",
+          "from": "vinyl@^0.2.1",
+          "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.2.3.tgz",
+          "dependencies": {
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@~0.0.1",
+              "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-wait": {
+      "version": "0.0.2",
+      "from": "gulp-wait@^0.0.2",
+      "resolved": "https://npm.webfilings.org/gulp-wait/-/gulp-wait-0.0.2.tgz",
+      "dependencies": {
+        "map-stream": {
+          "version": "0.0.4",
+          "from": "map-stream@0.0.4",
+          "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.0.4.tgz"
+        }
+      }
+    },
+    "jshint": {
+      "version": "2.6.3",
+      "from": "jshint@^2.5.0",
+      "resolved": "https://npm.webfilings.org/jshint/-/jshint-2.6.3.tgz",
+      "dependencies": {
+        "cli": {
+          "version": "0.6.5",
+          "from": "cli@0.6.x",
+          "resolved": "https://npm.webfilings.org/cli/-/cli-0.6.5.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@~ 3.2.1",
+              "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@1.1.x",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@^0.1.4",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@0.1.x",
+          "resolved": "https://npm.webfilings.org/exit/-/exit-0.1.2.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.2",
+          "from": "htmlparser2@3.8.x",
+          "resolved": "https://npm.webfilings.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@2.3",
+              "resolved": "https://npm.webfilings.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@1.5",
+              "resolved": "https://npm.webfilings.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@0",
+                  "resolved": "https://npm.webfilings.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@~1.1.1",
+                      "resolved": "https://npm.webfilings.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@~1.1.1",
+                      "resolved": "https://npm.webfilings.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@1",
+              "resolved": "https://npm.webfilings.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.10",
+              "from": "readable-stream@1.1",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "debuglog": {
+                  "version": "0.0.2",
+                  "from": "debuglog@0.0.2",
+                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@1.0",
+              "resolved": "https://npm.webfilings.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "from": "minimatch@1.0.x",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@0.3.x",
+          "resolved": "https://npm.webfilings.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@1.0.x",
+          "resolved": "https://npm.webfilings.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "from": "underscore@1.6.x",
+          "resolved": "https://npm.webfilings.org/underscore/-/underscore-1.6.0.tgz"
+        }
+      }
+    },
+    "jshint-stylish": {
+      "version": "1.0.1",
+      "from": "jshint-stylish@^1.0.0",
+      "resolved": "https://npm.webfilings.org/jshint-stylish/-/jshint-stylish-1.0.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@^1.0.0",
+          "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@^2.0.1",
+              "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@^1.0.2",
+              "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@^1.0.3",
+              "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@^2.0.1",
+              "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.0",
+              "from": "supports-color@^1.3.0",
+              "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "from": "log-symbols@^1.0.0",
+          "resolved": "https://npm.webfilings.org/log-symbols/-/log-symbols-1.0.2.tgz"
+        },
+        "string-length": {
+          "version": "1.0.0",
+          "from": "string-length@^1.0.0",
+          "resolved": "https://npm.webfilings.org/string-length/-/string-length-1.0.0.tgz",
+          "dependencies": {
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@^2.0.0",
+              "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@^0.2.0",
+          "resolved": "https://npm.webfilings.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
+    "karma": {
+      "version": "0.12.31",
+      "from": "karma@^0.12.23",
+      "resolved": "https://npm.webfilings.org/karma/-/karma-0.12.31.tgz",
+      "dependencies": {
+        "di": {
+          "version": "0.0.1",
+          "from": "di@~0.0.1",
+          "resolved": "https://npm.webfilings.org/di/-/di-0.0.1.tgz"
+        },
+        "socket.io": {
+          "version": "0.9.16",
+          "from": "socket.io@0.9.16",
+          "resolved": "https://npm.webfilings.org/socket.io/-/socket.io-0.9.16.tgz",
+          "dependencies": {
+            "socket.io-client": {
+              "version": "0.9.16",
+              "from": "socket.io-client@0.9.16",
+              "resolved": "https://npm.webfilings.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "dependencies": {
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "xmlhttprequest@1.4.2",
+                  "resolved": "https://npm.webfilings.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                },
+                "uglify-js": {
+                  "version": "1.2.5",
+                  "from": "uglify-js@1.2.5",
+                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-1.2.5.tgz"
+                },
+                "ws": {
+                  "version": "0.4.32",
+                  "from": "ws@0.4.x",
+                  "resolved": "https://npm.webfilings.org/ws/-/ws-0.4.32.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.1.0",
+                      "from": "commander@~2.1.0",
+                      "resolved": "https://npm.webfilings.org/commander/-/commander-2.1.0.tgz"
+                    },
+                    "nan": {
+                      "version": "1.0.0",
+                      "from": "nan@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/nan/-/nan-1.0.0.tgz"
+                    },
+                    "tinycolor": {
+                      "version": "0.0.1",
+                      "from": "tinycolor@0.x",
+                      "resolved": "https://npm.webfilings.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://npm.webfilings.org/options/-/options-0.0.6.tgz"
+                    }
+                  }
+                },
+                "active-x-obfuscator": {
+                  "version": "0.0.1",
+                  "from": "active-x-obfuscator@0.0.1",
+                  "resolved": "https://npm.webfilings.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "dependencies": {
+                    "zeparser": {
+                      "version": "0.0.5",
+                      "from": "zeparser@0.0.5",
+                      "resolved": "https://npm.webfilings.org/zeparser/-/zeparser-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0",
+              "resolved": "https://npm.webfilings.org/base64id/-/base64id-0.1.0.tgz"
+            },
+            "policyfile": {
+              "version": "0.0.4",
+              "from": "policyfile@0.0.4",
+              "resolved": "https://npm.webfilings.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "redis": {
+              "version": "0.7.3",
+              "from": "redis@0.7.3",
+              "resolved": "https://npm.webfilings.org/redis/-/redis-0.7.3.tgz"
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.0.0-rc4",
+          "from": "chokidar@>=0.8.2",
+          "resolved": "https://npm.webfilings.org/chokidar/-/chokidar-1.0.0-rc4.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.1.0",
+              "from": "anymatch@^1.1.0",
+              "resolved": "https://npm.webfilings.org/anymatch/-/anymatch-1.1.0.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.5.0",
+                      "from": "lru-cache@2",
+                      "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@^0.1.5",
+              "resolved": "https://npm.webfilings.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@^1.0.0",
+              "resolved": "https://npm.webfilings.org/glob-parent/-/glob-parent-1.2.0.tgz",
+              "dependencies": {
+                "is-glob": {
+                  "version": "1.1.3",
+                  "from": "is-glob@^1.1.1",
+                  "resolved": "https://npm.webfilings.org/is-glob/-/is-glob-1.1.3.tgz"
+                }
+              }
+            },
+            "is-binary-path": {
+              "version": "1.0.0",
+              "from": "is-binary-path@^1.0.0",
+              "resolved": "https://npm.webfilings.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.0",
+                  "from": "binary-extensions@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/binary-extensions/-/binary-extensions-1.3.0.tgz"
+                }
+              }
+            },
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "readdirp@^1.3.0",
+              "resolved": "https://npm.webfilings.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26-2",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "0.3.5",
+              "from": "fsevents@^0.3.1",
+              "resolved": "https://npm.webfilings.org/fsevents/-/fsevents-0.3.5.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.5.3",
+                  "from": "nan@~1.5.0",
+                  "resolved": "https://npm.webfilings.org/nan/-/nan-1.5.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@~3.2.7",
+          "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@0.3",
+              "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@~0.2",
+          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+            },
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "0.10.4",
+          "from": "http-proxy@~0.10",
+          "resolved": "https://npm.webfilings.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@0.3.x",
+              "resolved": "https://npm.webfilings.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@~0.2.1",
+              "resolved": "https://npm.webfilings.org/utile/-/utile-0.2.1.tgz",
+              "dependencies": {
+                "i": {
+                  "version": "0.3.2",
+                  "from": "i@0.3.x",
+                  "resolved": "https://npm.webfilings.org/i/-/i-0.3.2.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@*",
+                  "resolved": "https://npm.webfilings.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@0.4.x",
+                  "resolved": "https://npm.webfilings.org/ncp/-/ncp-0.4.2.tgz"
+                },
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@~0.2.9",
+                  "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@~0.6.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@~0.0.1",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@~2.2.5",
+          "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@~0.9.7",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.2",
+          "resolved": "https://npm.webfilings.org/colors/-/colors-0.6.2.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@~1.2.11",
+          "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+        },
+        "log4js": {
+          "version": "0.6.22",
+          "from": "log4js@~0.6.3",
+          "resolved": "https://npm.webfilings.org/log4js/-/log4js-0.6.22.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.0",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "1.1.4",
+              "from": "semver@~1.1.4",
+              "resolved": "https://npm.webfilings.org/semver/-/semver-1.1.4.tgz"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.10",
+          "from": "useragent@~2.0.4",
+          "resolved": "https://npm.webfilings.org/useragent/-/useragent-2.0.10.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "lru-cache@2.2.x",
+              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "from": "graceful-fs@~2.0.1",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+        },
+        "connect": {
+          "version": "2.26.6",
+          "from": "connect@~2.26.0",
+          "resolved": "https://npm.webfilings.org/connect/-/connect-2.26.6.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://npm.webfilings.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.8.4",
+              "from": "body-parser@~1.8.4",
+              "resolved": "https://npm.webfilings.org/body-parser/-/body-parser-1.8.4.tgz",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@0.4.4",
+                  "resolved": "https://npm.webfilings.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "from": "raw-body@1.3.0",
+                  "resolved": "https://npm.webfilings.org/raw-body/-/raw-body-1.3.0.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://npm.webfilings.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://npm.webfilings.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.3.4",
+              "from": "cookie-parser@~1.3.3",
+              "resolved": "https://npm.webfilings.org/cookie-parser/-/cookie-parser-1.3.4.tgz",
+              "dependencies": {
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "from": "cookie-signature@1.0.6",
+                  "resolved": "https://npm.webfilings.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                }
+              }
+            },
+            "cookie-signature": {
+              "version": "1.0.5",
+              "from": "cookie-signature@1.0.5",
+              "resolved": "https://npm.webfilings.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+            },
+            "compression": {
+              "version": "1.1.2",
+              "from": "compression@~1.1.2",
+              "resolved": "https://npm.webfilings.org/compression/-/compression-1.1.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@~1.1.3",
+                  "resolved": "https://npm.webfilings.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.9",
+                      "from": "mime-types@~2.0.4",
+                      "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.7.0",
+                          "from": "mime-db@~1.7.0",
+                          "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "compressible": {
+                  "version": "2.0.2",
+                  "from": "compressible@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/compressible/-/compressible-2.0.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>= 1.1.2 < 2",
+                      "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/vary/-/vary-1.0.0.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.3.0",
+              "from": "connect-timeout@~1.3.0",
+              "resolved": "https://npm.webfilings.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "csurf": {
+              "version": "1.6.6",
+              "from": "csurf@~1.6.2",
+              "resolved": "https://npm.webfilings.org/csurf/-/csurf-1.6.6.tgz",
+              "dependencies": {
+                "csrf": {
+                  "version": "2.0.6",
+                  "from": "csrf@~2.0.5",
+                  "resolved": "https://npm.webfilings.org/csrf/-/csrf-2.0.6.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://npm.webfilings.org/base64-url/-/base64-url-1.2.1.tgz"
+                    },
+                    "rndm": {
+                      "version": "1.1.0",
+                      "from": "rndm@~1.1.0",
+                      "resolved": "https://npm.webfilings.org/rndm/-/rndm-1.1.0.tgz"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0",
+                      "resolved": "https://npm.webfilings.org/scmp/-/scmp-1.0.0.tgz"
+                    },
+                    "uid-safe": {
+                      "version": "1.1.0",
+                      "from": "uid-safe@~1.1.0",
+                      "resolved": "https://npm.webfilings.org/uid-safe/-/uid-safe-1.1.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.1.2",
+                          "from": "native-or-bluebird@~1.1.2",
+                          "resolved": "https://npm.webfilings.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-errors": {
+                  "version": "1.2.8",
+                  "from": "http-errors@~1.2.8",
+                  "resolved": "https://npm.webfilings.org/http-errors/-/http-errors-1.2.8.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@1",
+                      "resolved": "https://npm.webfilings.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@~2.0.0",
+              "resolved": "https://npm.webfilings.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://npm.webfilings.org/depd/-/depd-0.4.5.tgz"
+            },
+            "errorhandler": {
+              "version": "1.2.4",
+              "from": "errorhandler@~1.2.2",
+              "resolved": "https://npm.webfilings.org/errorhandler/-/errorhandler-1.2.4.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@~1.1.3",
+                  "resolved": "https://npm.webfilings.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.9",
+                      "from": "mime-types@~2.0.4",
+                      "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.7.0",
+                          "from": "mime-db@~1.7.0",
+                          "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "express-session": {
+              "version": "1.8.2",
+              "from": "express-session@~1.8.2",
+              "resolved": "https://npm.webfilings.org/express-session/-/express-session-1.8.2.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.0.0",
+                  "from": "crc@3.0.0",
+                  "resolved": "https://npm.webfilings.org/crc/-/crc-3.0.0.tgz"
+                },
+                "uid-safe": {
+                  "version": "1.0.1",
+                  "from": "uid-safe@1.0.1",
+                  "resolved": "https://npm.webfilings.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "dependencies": {
+                    "mz": {
+                      "version": "1.3.0",
+                      "from": "mz@1",
+                      "resolved": "https://npm.webfilings.org/mz/-/mz-1.3.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.2.0",
+                          "from": "native-or-bluebird@1",
+                          "resolved": "https://npm.webfilings.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+                        },
+                        "thenify": {
+                          "version": "3.1.0",
+                          "from": "thenify@3",
+                          "resolved": "https://npm.webfilings.org/thenify/-/thenify-3.1.0.tgz"
+                        },
+                        "thenify-all": {
+                          "version": "1.6.0",
+                          "from": "thenify-all@1",
+                          "resolved": "https://npm.webfilings.org/thenify-all/-/thenify-all-1.6.0.tgz"
+                        }
+                      }
+                    },
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1",
+                      "resolved": "https://npm.webfilings.org/base64-url/-/base64-url-1.2.1.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.2.0",
+              "from": "finalhandler@0.2.0",
+              "resolved": "https://npm.webfilings.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4",
+              "resolved": "https://npm.webfilings.org/fresh/-/fresh-0.2.4.tgz"
+            },
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://npm.webfilings.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "method-override": {
+              "version": "2.2.0",
+              "from": "method-override@~2.2.0",
+              "resolved": "https://npm.webfilings.org/method-override/-/method-override-2.2.0.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.0",
+                  "from": "methods@1.1.0",
+                  "resolved": "https://npm.webfilings.org/methods/-/methods-1.1.0.tgz"
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/vary/-/vary-1.0.0.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.3.2",
+              "from": "morgan@~1.3.2",
+              "resolved": "https://npm.webfilings.org/morgan/-/morgan-1.3.2.tgz",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.0",
+                  "from": "basic-auth@1.0.0",
+                  "resolved": "https://npm.webfilings.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "multiparty": {
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "resolved": "https://npm.webfilings.org/multiparty/-/multiparty-3.3.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.10",
+                  "from": "readable-stream@~1.1.9",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "debuglog": {
+                      "version": "0.0.2",
+                      "from": "debuglog@0.0.2",
+                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@~0.2.0",
+                  "resolved": "https://npm.webfilings.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.0",
+              "from": "on-headers@~1.0.0",
+              "resolved": "https://npm.webfilings.org/on-headers/-/on-headers-1.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@~1.3.0",
+              "resolved": "https://npm.webfilings.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "qs": {
+              "version": "2.2.4",
+              "from": "qs@2.2.4",
+              "resolved": "https://npm.webfilings.org/qs/-/qs-2.2.4.tgz"
+            },
+            "response-time": {
+              "version": "2.0.1",
+              "from": "response-time@~2.0.1",
+              "resolved": "https://npm.webfilings.org/response-time/-/response-time-2.0.1.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.1.7",
+              "from": "serve-favicon@~2.1.5",
+              "resolved": "https://npm.webfilings.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
+              "dependencies": {
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@~1.5.0",
+                  "resolved": "https://npm.webfilings.org/etag/-/etag-1.5.1.tgz",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://npm.webfilings.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                },
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.2.1",
+              "from": "serve-index@~1.2.1",
+              "resolved": "https://npm.webfilings.org/serve-index/-/serve-index-1.2.1.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@~1.1.0",
+                  "resolved": "https://npm.webfilings.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.9",
+                      "from": "mime-types@~2.0.4",
+                      "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-2.0.9.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.7.0",
+                          "from": "mime-db@~1.7.0",
+                          "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.1",
+                  "from": "batch@0.5.1",
+                  "resolved": "https://npm.webfilings.org/batch/-/batch-0.5.1.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.6.5",
+              "from": "serve-static@~1.6.4",
+              "resolved": "https://npm.webfilings.org/serve-static/-/serve-static-1.6.5.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.9.3",
+                  "from": "send@0.9.3",
+                  "resolved": "https://npm.webfilings.org/send/-/send-0.9.3.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.3",
+                      "from": "destroy@1.0.3",
+                      "resolved": "https://npm.webfilings.org/destroy/-/destroy-1.0.3.tgz"
+                    },
+                    "etag": {
+                      "version": "1.4.0",
+                      "from": "etag@~1.4.0",
+                      "resolved": "https://npm.webfilings.org/etag/-/etag-1.4.0.tgz",
+                      "dependencies": {
+                        "crc": {
+                          "version": "3.0.0",
+                          "from": "crc@3.0.0",
+                          "resolved": "https://npm.webfilings.org/crc/-/crc-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.1.0",
+                      "from": "on-finished@2.1.0",
+                      "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.0.5",
+                          "from": "ee-first@1.0.5",
+                          "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@~1.0.2",
+                      "resolved": "https://npm.webfilings.org/range-parser/-/range-parser-1.0.2.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.5.7",
+              "from": "type-is@~1.5.2",
+              "resolved": "https://npm.webfilings.org/type-is/-/type-is-1.5.7.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.9",
+                  "from": "mime-types@~2.0.9",
+                  "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-2.0.9.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.7.0",
+                      "from": "mime-db@>= 1.1.2 < 2",
+                      "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vhost": {
+              "version": "3.0.0",
+              "from": "vhost@~3.0.0",
+              "resolved": "https://npm.webfilings.org/vhost/-/vhost-3.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://npm.webfilings.org/pause/-/pause-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-browserifast": {
+      "version": "0.7.0",
+      "from": "karma-browserifast@^0.7.0",
+      "resolved": "https://npm.webfilings.org/karma-browserifast/-/karma-browserifast-0.7.0.tgz",
+      "dependencies": {
+        "browserify": {
+          "version": "4.2.3",
+          "from": "browserify@^4.2.0",
+          "resolved": "https://npm.webfilings.org/browserify/-/browserify-4.2.3.tgz",
+          "dependencies": {
+            "JSONStream": {
+              "version": "0.8.4",
+              "from": "JSONStream@~0.8.3",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.4.tgz",
+              "dependencies": {
+                "jsonparse": {
+                  "version": "0.0.5",
+                  "from": "jsonparse@0.0.5",
+                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@>=2.2.7 <3",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "assert": {
+              "version": "1.1.2",
+              "from": "assert@~1.1.0",
+              "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+            },
+            "browser-pack": {
+              "version": "2.0.1",
+              "from": "browser-pack@~2.0.0",
+              "resolved": "https://npm.webfilings.org/browser-pack/-/browser-pack-2.0.1.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.6.4",
+                  "from": "JSONStream@~0.6.4",
+                  "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.6.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.2.7",
+                      "from": "through@~2.2.7",
+                      "resolved": "https://npm.webfilings.org/through/-/through-2.2.7.tgz"
+                    }
+                  }
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@~2.3.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                },
+                "combine-source-map": {
+                  "version": "0.3.0",
+                  "from": "combine-source-map@~0.3.0",
+                  "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+                  "dependencies": {
+                    "inline-source-map": {
+                      "version": "0.3.1",
+                      "from": "inline-source-map@~0.3.0",
+                      "resolved": "https://npm.webfilings.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+                      "dependencies": {
+                        "source-map": {
+                          "version": "0.3.0",
+                          "from": "source-map@~0.3.0",
+                          "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.3.0.tgz",
+                          "dependencies": {
+                            "amdefine": {
+                              "version": "0.1.0",
+                              "from": "amdefine@>=0.0.4",
+                              "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "browser-resolve": {
+              "version": "1.7.2",
+              "from": "browser-resolve@^1.3.0",
+              "resolved": "https://npm.webfilings.org/browser-resolve/-/browser-resolve-1.7.2.tgz",
+              "dependencies": {
+                "resolve": {
+                  "version": "1.1.5",
+                  "from": "resolve@1.1.5",
+                  "resolved": "https://npm.webfilings.org/resolve/-/resolve-1.1.5.tgz"
+                }
+              }
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@~0.1.2",
+              "resolved": "https://npm.webfilings.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.5",
+                  "from": "pako@~0.2.0",
+                  "resolved": "https://npm.webfilings.org/pako/-/pako-0.2.5.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "2.8.2",
+              "from": "buffer@^2.3.0",
+              "resolved": "https://npm.webfilings.org/buffer/-/buffer-2.8.2.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "0.0.7",
+                  "from": "base64-js@0.0.7",
+                  "resolved": "https://npm.webfilings.org/base64-js/-/base64-js-0.0.7.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.4",
+                  "from": "ieee754@^1.1.4",
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                },
+                "is-array": {
+                  "version": "1.0.1",
+                  "from": "is-array@^1.0.1",
+                  "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                }
+              }
+            },
+            "builtins": {
+              "version": "0.0.7",
+              "from": "builtins@~0.0.3",
+              "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+            },
+            "commondir": {
+              "version": "0.0.1",
+              "from": "commondir@0.0.1",
+              "resolved": "https://npm.webfilings.org/commondir/-/commondir-0.0.1.tgz"
+            },
+            "concat-stream": {
+              "version": "1.4.7",
+              "from": "concat-stream@~1.4.1",
+              "resolved": "https://npm.webfilings.org/concat-stream/-/concat-stream-1.4.7.tgz",
+              "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@~0.0.5",
+                  "resolved": "https://npm.webfilings.org/typedarray/-/typedarray-0.0.6.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@^1.1.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@^0.1.4",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "0.0.1",
+              "from": "constants-browserify@~0.0.1",
+              "resolved": "https://npm.webfilings.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+            },
+            "crypto-browserify": {
+              "version": "2.1.10",
+              "from": "crypto-browserify@^2.1.8",
+              "resolved": "https://npm.webfilings.org/crypto-browserify/-/crypto-browserify-2.1.10.tgz",
+              "dependencies": {
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "ripemd160@0.2.0",
+                  "resolved": "https://npm.webfilings.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.1.6",
+                  "from": "sha.js@2.1.6",
+                  "resolved": "https://npm.webfilings.org/sha.js/-/sha.js-2.1.6.tgz",
+                  "dependencies": {
+                    "buffer": {
+                      "version": "2.3.4",
+                      "from": "buffer@~2.3.2",
+                      "resolved": "https://npm.webfilings.org/buffer/-/buffer-2.3.4.tgz",
+                      "dependencies": {
+                        "base64-js": {
+                          "version": "0.0.8",
+                          "from": "base64-js@~0.0.4",
+                          "resolved": "https://npm.webfilings.org/base64-js/-/base64-js-0.0.8.tgz"
+                        },
+                        "ieee754": {
+                          "version": "1.1.4",
+                          "from": "ieee754@~1.1.1",
+                          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "deep-equal": {
+              "version": "0.2.2",
+              "from": "deep-equal@~0.2.1",
+              "resolved": "https://npm.webfilings.org/deep-equal/-/deep-equal-0.2.2.tgz"
+            },
+            "defined": {
+              "version": "0.0.0",
+              "from": "defined@~0.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+            },
+            "deps-sort": {
+              "version": "0.1.2",
+              "from": "deps-sort@~0.1.1",
+              "resolved": "https://npm.webfilings.org/deps-sort/-/deps-sort-0.1.2.tgz",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@~2.3.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                },
+                "JSONStream": {
+                  "version": "0.6.4",
+                  "from": "JSONStream@~0.6.4",
+                  "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.6.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.2.7",
+                      "from": "through@~2.2.7",
+                      "resolved": "https://npm.webfilings.org/through/-/through-2.2.7.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.7",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "derequire": {
+              "version": "0.8.0",
+              "from": "derequire@~0.8.0",
+              "resolved": "https://npm.webfilings.org/derequire/-/derequire-0.8.0.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esrefactor": {
+                  "version": "0.1.0",
+                  "from": "esrefactor@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "1.0.4",
+                      "from": "esprima@~1.0.2",
+                      "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
+                    },
+                    "estraverse": {
+                      "version": "0.0.4",
+                      "from": "estraverse@~0.0.4",
+                      "resolved": "https://npm.webfilings.org/estraverse/-/estraverse-0.0.4.tgz"
+                    },
+                    "escope": {
+                      "version": "0.0.16",
+                      "from": "escope@~0.0.13",
+                      "resolved": "https://npm.webfilings.org/escope/-/escope-0.0.16.tgz"
+                    }
+                  }
+                },
+                "esprima-fb": {
+                  "version": "3001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@^3001.1.0-dev-harmony-fb",
+                  "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.4",
+              "from": "domain-browser@~1.1.0",
+              "resolved": "https://npm.webfilings.org/domain-browser/-/domain-browser-1.1.4.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "events": {
+              "version": "1.0.2",
+              "from": "events@~1.0.0",
+              "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+            },
+            "http-browserify": {
+              "version": "1.7.0",
+              "from": "http-browserify@^1.4.0",
+              "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+              "dependencies": {
+                "Base64": {
+                  "version": "0.2.1",
+                  "from": "Base64@~0.2.0",
+                  "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                }
+              }
+            },
+            "https-browserify": {
+              "version": "0.0.0",
+              "from": "https-browserify@~0.0.0",
+              "resolved": "https://npm.webfilings.org/https-browserify/-/https-browserify-0.0.0.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@~2.0.1",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "insert-module-globals": {
+              "version": "6.0.0",
+              "from": "insert-module-globals@~6.0.0",
+              "resolved": "https://npm.webfilings.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.7.4",
+                  "from": "JSONStream@~0.7.1",
+                  "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    }
+                  }
+                },
+                "lexical-scope": {
+                  "version": "1.1.0",
+                  "from": "lexical-scope@~1.1.0",
+                  "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.0.tgz",
+                  "dependencies": {
+                    "astw": {
+                      "version": "1.1.0",
+                      "from": "astw@~1.1.0",
+                      "resolved": "https://npm.webfilings.org/astw/-/astw-1.1.0.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "3001.1.0-dev-harmony-fb",
+                          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                          "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "process": {
+                  "version": "0.6.0",
+                  "from": "process@~0.6.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@~2.3.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                }
+              }
+            },
+            "module-deps": {
+              "version": "2.1.5",
+              "from": "module-deps@~2.1.1",
+              "resolved": "https://npm.webfilings.org/module-deps/-/module-deps-2.1.5.tgz",
+              "dependencies": {
+                "JSONStream": {
+                  "version": "0.7.4",
+                  "from": "JSONStream@~0.7.1",
+                  "resolved": "https://npm.webfilings.org/JSONStream/-/JSONStream-0.7.4.tgz",
+                  "dependencies": {
+                    "jsonparse": {
+                      "version": "0.0.5",
+                      "from": "jsonparse@0.0.5",
+                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@>=2.2.7 <3",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "browser-resolve": {
+                  "version": "1.2.4",
+                  "from": "browser-resolve@~1.2.4",
+                  "resolved": "https://npm.webfilings.org/browser-resolve/-/browser-resolve-1.2.4.tgz"
+                },
+                "detective": {
+                  "version": "3.1.0",
+                  "from": "detective@~3.1.0",
+                  "resolved": "https://npm.webfilings.org/detective/-/detective-3.1.0.tgz",
+                  "dependencies": {
+                    "escodegen": {
+                      "version": "1.1.0",
+                      "from": "escodegen@~1.1.0",
+                      "resolved": "https://npm.webfilings.org/escodegen/-/escodegen-1.1.0.tgz",
+                      "dependencies": {
+                        "esutils": {
+                          "version": "1.0.0",
+                          "from": "esutils@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/esutils/-/esutils-1.0.0.tgz"
+                        },
+                        "esprima": {
+                          "version": "1.0.4",
+                          "from": "esprima@~1.0.4",
+                          "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
+                        },
+                        "estraverse": {
+                          "version": "1.5.1",
+                          "from": "estraverse@~1.5.0",
+                          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "3001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+                      "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+                    }
+                  }
+                },
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.9",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                },
+                "parents": {
+                  "version": "0.0.2",
+                  "from": "parents@0.0.2",
+                  "resolved": "https://npm.webfilings.org/parents/-/parents-0.0.2.tgz"
+                },
+                "resolve": {
+                  "version": "0.6.3",
+                  "from": "resolve@~0.6.3",
+                  "resolved": "https://npm.webfilings.org/resolve/-/resolve-0.6.3.tgz"
+                },
+                "stream-combiner": {
+                  "version": "0.1.0",
+                  "from": "stream-combiner@~0.1.0",
+                  "resolved": "https://npm.webfilings.org/stream-combiner/-/stream-combiner-0.1.0.tgz",
+                  "dependencies": {
+                    "through": {
+                      "version": "2.3.6",
+                      "from": "through@~2.3.4",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.4.2",
+                  "from": "through2@~0.4.1",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.17",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "2.1.2",
+                      "from": "xtend@~2.1.1",
+                      "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+                      "dependencies": {
+                        "object-keys": {
+                          "version": "0.4.0",
+                          "from": "object-keys@~0.4.0",
+                          "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "os-browserify": {
+              "version": "0.1.2",
+              "from": "os-browserify@~0.1.1",
+              "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+            },
+            "parents": {
+              "version": "0.0.3",
+              "from": "parents@~0.0.1",
+              "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz",
+              "dependencies": {
+                "path-platform": {
+                  "version": "0.0.1",
+                  "from": "path-platform@^0.0.1",
+                  "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
+                }
+              }
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@~0.0.0",
+              "resolved": "https://npm.webfilings.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "punycode": {
+              "version": "1.2.4",
+              "from": "punycode@~1.2.3",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@~0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.10",
+              "from": "readable-stream@^1.0.33-1",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "debuglog": {
+                  "version": "0.0.2",
+                  "from": "debuglog@0.0.2",
+                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "from": "resolve@~0.7.1",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "shallow-copy": {
+              "version": "0.0.1",
+              "from": "shallow-copy@0.0.1",
+              "resolved": "https://npm.webfilings.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+            },
+            "shell-quote": {
+              "version": "0.0.1",
+              "from": "shell-quote@~0.0.1",
+              "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+            },
+            "stream-browserify": {
+              "version": "1.0.0",
+              "from": "stream-browserify@^1.0.0",
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@~0.0.2",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            },
+            "string_decoder": {
+              "version": "0.0.1",
+              "from": "string_decoder@~0.0.0",
+              "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.0.1.tgz"
+            },
+            "subarg": {
+              "version": "0.0.1",
+              "from": "subarg@0.0.1",
+              "resolved": "https://npm.webfilings.org/subarg/-/subarg-0.0.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.7",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "syntax-error": {
+              "version": "1.1.2",
+              "from": "syntax-error@^1.1.1",
+              "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "0.9.0",
+                  "from": "acorn@~0.9.0",
+                  "resolved": "https://npm.webfilings.org/acorn/-/acorn-0.9.0.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "1.1.1",
+              "from": "through2@^1.0.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-1.1.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "timers-browserify": {
+              "version": "1.4.0",
+              "from": "timers-browserify@^1.0.1",
+              "resolved": "https://npm.webfilings.org/timers-browserify/-/timers-browserify-1.4.0.tgz",
+              "dependencies": {
+                "process": {
+                  "version": "0.10.1",
+                  "from": "process@~0.10.0",
+                  "resolved": "https://npm.webfilings.org/process/-/process-0.10.1.tgz"
+                }
+              }
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@~0.0.0",
+              "resolved": "https://npm.webfilings.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "umd": {
+              "version": "2.1.0",
+              "from": "umd@~2.1.0",
+              "resolved": "https://registry.npmjs.org/umd/-/umd-2.1.0.tgz",
+              "dependencies": {
+                "rfile": {
+                  "version": "1.0.0",
+                  "from": "rfile@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+                  "dependencies": {
+                    "callsite": {
+                      "version": "1.0.0",
+                      "from": "callsite@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/callsite/-/callsite-1.0.0.tgz"
+                    },
+                    "resolve": {
+                      "version": "0.3.1",
+                      "from": "resolve@~0.3.0",
+                      "resolved": "https://npm.webfilings.org/resolve/-/resolve-0.3.1.tgz"
+                    }
+                  }
+                },
+                "ruglify": {
+                  "version": "1.0.0",
+                  "from": "ruglify@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+                  "dependencies": {
+                    "uglify-js": {
+                      "version": "2.2.5",
+                      "from": "uglify-js@~2.2",
+                      "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.2.5.tgz",
+                      "dependencies": {
+                        "optimist": {
+                          "version": "0.3.7",
+                          "from": "optimist@~0.3.5",
+                          "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz",
+                          "dependencies": {
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@~0.0.2",
+                              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "through": {
+                  "version": "2.3.6",
+                  "from": "through@~2.3.4",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+                },
+                "uglify-js": {
+                  "version": "2.4.16",
+                  "from": "uglify-js@~2.4.0",
+                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@~0.2.6",
+                      "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.34",
+                      "from": "source-map@0.1.34",
+                      "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.34.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "optimist": {
+                      "version": "0.3.7",
+                      "from": "optimist@~0.3.5",
+                      "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz",
+                      "dependencies": {
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@~0.0.2",
+                          "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                        }
+                      }
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "from": "uglify-to-browserify@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "url": {
+              "version": "0.10.3",
+              "from": "url@~0.10.1",
+              "resolved": "https://npm.webfilings.org/url/-/url-0.10.3.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@1.3.2",
+                  "resolved": "https://npm.webfilings.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "https://npm.webfilings.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@~0.10.1",
+              "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@~0.0.1",
+              "resolved": "https://npm.webfilings.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@^3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            },
+            "process": {
+              "version": "0.7.0",
+              "from": "process@^0.7.0",
+              "resolved": "https://npm.webfilings.org/process/-/process-0.7.0.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@~3.2",
+          "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@0.3",
+              "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "0.8.4",
+          "from": "chokidar@~0.8",
+          "resolved": "https://npm.webfilings.org/chokidar/-/chokidar-0.8.4.tgz",
+          "dependencies": {
+            "fsevents": {
+              "version": "0.2.1",
+              "from": "fsevents@git+https://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
+              "resolved": "git+https://github.com/pipobscure/fsevents#7dcdf9fa3f8956610fd6f69f72c67bace2de7138",
+              "dependencies": {
+                "nan": {
+                  "version": "0.8.0",
+                  "from": "nan@~0.8.0",
+                  "resolved": "https://npm.webfilings.org/nan/-/nan-0.8.0.tgz"
+                }
+              }
+            },
+            "recursive-readdir": {
+              "version": "0.0.2",
+              "from": "recursive-readdir@0.0.2",
+              "resolved": "https://npm.webfilings.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "0.3.5",
+          "from": "convert-source-map@~0.3.3",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+        }
+      }
+    },
+    "karma-chai": {
+      "version": "0.1.0",
+      "from": "karma-chai@^0.1.0",
+      "resolved": "https://npm.webfilings.org/karma-chai/-/karma-chai-0.1.0.tgz"
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.7",
+      "from": "karma-chrome-launcher@^0.1.4",
+      "resolved": "https://npm.webfilings.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.7.tgz"
+    },
+    "karma-coverage": {
+      "version": "0.2.7",
+      "from": "karma-coverage@^0.2.6",
+      "resolved": "https://npm.webfilings.org/karma-coverage/-/karma-coverage-0.2.7.tgz",
+      "dependencies": {
+        "istanbul": {
+          "version": "0.3.7",
+          "from": "istanbul@~0.3.0",
+          "resolved": "https://npm.webfilings.org/istanbul/-/istanbul-0.3.7.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "2.0.0",
+              "from": "esprima@2.0.x",
+              "resolved": "https://npm.webfilings.org/esprima/-/esprima-2.0.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.3.3",
+              "from": "escodegen@1.3.x",
+              "resolved": "https://npm.webfilings.org/escodegen/-/escodegen-1.3.3.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "1.0.0",
+                  "from": "esutils@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/esutils/-/esutils-1.0.0.tgz"
+                },
+                "estraverse": {
+                  "version": "1.5.1",
+                  "from": "estraverse@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+                },
+                "esprima": {
+                  "version": "1.1.1",
+                  "from": "esprima@~1.1.1",
+                  "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.1.1.tgz"
+                }
+              }
+            },
+            "handlebars": {
+              "version": "1.3.0",
+              "from": "handlebars@1.3.x",
+              "resolved": "https://npm.webfilings.org/handlebars/-/handlebars-1.3.0.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@~0.3",
+                  "resolved": "https://npm.webfilings.org/optimist/-/optimist-0.3.7.tgz"
+                },
+                "uglify-js": {
+                  "version": "2.3.6",
+                  "from": "uglify-js@~2.3",
+                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.3.6.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@~0.2.6",
+                      "resolved": "https://npm.webfilings.org/async/-/async-0.2.10.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@3.x",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@0.1.x",
+              "resolved": "https://npm.webfilings.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@3.x",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@1.0.x",
+              "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@0.9.x",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+            },
+            "supports-color": {
+              "version": "1.2.1",
+              "from": "supports-color@1.2.x",
+              "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.2.1.tgz"
+            },
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@1.0.x",
+              "resolved": "https://npm.webfilings.org/abbrev/-/abbrev-1.0.5.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@0.0.x",
+              "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            },
+            "resolve": {
+              "version": "0.7.4",
+              "from": "resolve@0.7.x",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.7.4.tgz"
+            },
+            "js-yaml": {
+              "version": "3.2.7",
+              "from": "js-yaml@3.x",
+              "resolved": "https://npm.webfilings.org/js-yaml/-/js-yaml-3.2.7.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.1",
+                  "from": "argparse@~ 1.0.0",
+                  "resolved": "https://npm.webfilings.org/argparse/-/argparse-1.0.1.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.2.0",
+                      "from": "lodash@~3.2",
+                      "resolved": "https://npm.webfilings.org/lodash/-/lodash-3.2.0.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "sprintf-js@~1.0.2",
+                      "resolved": "https://npm.webfilings.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@1.x",
+              "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ibrik": {
+          "version": "2.0.0",
+          "from": "ibrik@~2.0.0",
+          "resolved": "https://npm.webfilings.org/ibrik/-/ibrik-2.0.0.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.8.0",
+              "from": "coffee-script@~1.8.0",
+              "resolved": "https://npm.webfilings.org/coffee-script/-/coffee-script-1.8.0.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.3.5",
+                  "from": "mkdirp@~0.3.5",
+                  "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                }
+              }
+            },
+            "estraverse": {
+              "version": "1.8.0",
+              "from": "estraverse@~1.8.0",
+              "resolved": "https://npm.webfilings.org/estraverse/-/estraverse-1.8.0.tgz"
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@~1.0.5",
+              "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@~0.6.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@~0.0.2",
+                  "resolved": "https://npm.webfilings.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@~0.0.1",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@1.2.x",
+              "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "fileset": {
+              "version": "0.1.5",
+              "from": "fileset@0.1.x",
+              "resolved": "https://npm.webfilings.org/fileset/-/fileset-0.1.5.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@3.x",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@^1.0.11",
+          "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@*",
+              "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@*",
+              "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.0.2",
+                      "from": "camelcase@^1.0.1",
+                      "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.0",
+                      "from": "map-obj@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.0",
+                          "from": "is-finite@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.0",
+                  "from": "minimist@^1.1.0",
+                  "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@^2.0.0",
+                  "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@~0.3.0",
+          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-firefox-launcher": {
+      "version": "0.1.4",
+      "from": "karma-firefox-launcher@^0.1.3",
+      "resolved": "https://npm.webfilings.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.4.tgz"
+    },
+    "karma-jasmine": {
+      "version": "0.2.3",
+      "from": "karma-jasmine@^0.2.2",
+      "resolved": "https://npm.webfilings.org/karma-jasmine/-/karma-jasmine-0.2.3.tgz"
+    },
+    "karma-jasmine-html-reporter": {
+      "version": "0.1.6",
+      "from": "karma-jasmine-html-reporter@^0.1.5",
+      "resolved": "https://npm.webfilings.org/karma-jasmine-html-reporter/-/karma-jasmine-html-reporter-0.1.6.tgz"
+    },
+    "karma-jasmine-html-reporter-livereload": {
+      "version": "1.0.0",
+      "from": "karma-jasmine-html-reporter-livereload@^1.0.0",
+      "resolved": "https://npm.webfilings.org/karma-jasmine-html-reporter-livereload/-/karma-jasmine-html-reporter-livereload-1.0.0.tgz"
+    },
+    "karma-jspm": {
+      "version": "1.1.4",
+      "from": "karma-jspm@^1.0.0",
+      "resolved": "https://npm.webfilings.org/karma-jspm/-/karma-jspm-1.1.4.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@~3.2",
+          "resolved": "https://npm.webfilings.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@0.3",
+              "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.5.0",
+                  "from": "lru-cache@2",
+                  "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "karma-junit-reporter": {
+      "version": "0.2.2",
+      "from": "karma-junit-reporter@^0.2.2",
+      "resolved": "https://npm.webfilings.org/karma-junit-reporter/-/karma-junit-reporter-0.2.2.tgz",
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "0.4.2",
+          "from": "xmlbuilder@0.4.2",
+          "resolved": "https://npm.webfilings.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+        }
+      }
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.1.4",
+      "from": "karma-phantomjs-launcher@^0.1.4",
+      "resolved": "https://npm.webfilings.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz"
+    },
+    "karma-requirejs": {
+      "version": "0.2.2",
+      "from": "karma-requirejs@^0.2.2",
+      "resolved": "https://npm.webfilings.org/karma-requirejs/-/karma-requirejs-0.2.2.tgz"
+    },
+    "karma-sauce-launcher": {
+      "version": "0.2.10",
+      "from": "karma-sauce-launcher@^0.2.10",
+      "resolved": "https://npm.webfilings.org/karma-sauce-launcher/-/karma-sauce-launcher-0.2.10.tgz",
+      "dependencies": {
+        "wd": {
+          "version": "0.3.11",
+          "from": "wd@~0.3.4",
+          "resolved": "https://npm.webfilings.org/wd/-/wd-0.3.11.tgz",
+          "dependencies": {
+            "archiver": {
+              "version": "0.12.0",
+              "from": "archiver@~0.12.0",
+              "resolved": "https://npm.webfilings.org/archiver/-/archiver-0.12.0.tgz",
+              "dependencies": {
+                "buffer-crc32": {
+                  "version": "0.2.5",
+                  "from": "buffer-crc32@~0.2.1",
+                  "resolved": "https://npm.webfilings.org/buffer-crc32/-/buffer-crc32-0.2.5.tgz"
+                },
+                "glob": {
+                  "version": "4.0.6",
+                  "from": "glob@~4.0.6",
+                  "resolved": "https://npm.webfilings.org/glob/-/glob-4.0.6.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.5",
+                      "from": "graceful-fs@^3.0.2",
+                      "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "from": "minimatch@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2",
+                          "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.1",
+                      "from": "once@^1.3.0",
+                      "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1",
+                          "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lazystream": {
+                  "version": "0.1.0",
+                  "from": "lazystream@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "tar-stream": {
+                  "version": "1.0.2",
+                  "from": "tar-stream@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/tar-stream/-/tar-stream-1.0.2.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@^0.9.0",
+                      "resolved": "https://npm.webfilings.org/bl/-/bl-0.9.4.tgz"
+                    },
+                    "end-of-stream": {
+                      "version": "1.1.0",
+                      "from": "end-of-stream@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.1",
+                          "from": "once@~1.3.0",
+                          "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1",
+                              "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "zip-stream": {
+                  "version": "0.4.1",
+                  "from": "zip-stream@~0.4.0",
+                  "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.4.1.tgz",
+                  "dependencies": {
+                    "compress-commons": {
+                      "version": "0.1.6",
+                      "from": "compress-commons@~0.1.0",
+                      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.1.6.tgz",
+                      "dependencies": {
+                        "crc32-stream": {
+                          "version": "0.3.2",
+                          "from": "crc32-stream@~0.3.1",
+                          "resolved": "https://npm.webfilings.org/crc32-stream/-/crc32-stream-0.3.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "0.9.0",
+              "from": "async@~0.9.0",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+            },
+            "q": {
+              "version": "1.0.1",
+              "from": "q@~1.0.1",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+            },
+            "request": {
+              "version": "2.46.0",
+              "from": "request@~2.46.0",
+              "resolved": "https://npm.webfilings.org/request/-/request-2.46.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@~0.9.0",
+                  "resolved": "https://npm.webfilings.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.26",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@~0.6.0",
+                  "resolved": "https://npm.webfilings.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0",
+                  "resolved": "https://npm.webfilings.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@~0.1.0",
+                  "resolved": "https://npm.webfilings.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@~0.0.4",
+                      "resolved": "https://npm.webfilings.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://npm.webfilings.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.11",
+                      "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.0",
+                  "from": "json-stringify-safe@~5.0.0",
+                  "resolved": "https://npm.webfilings.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@~1.0.1",
+                  "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@~1.4.0",
+                  "resolved": "https://npm.webfilings.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@~1.2.0",
+                  "resolved": "https://npm.webfilings.org/qs/-/qs-1.2.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@~0.4.0",
+                  "resolved": "https://npm.webfilings.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "0.12.1",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://npm.webfilings.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.3.2",
+                      "from": "punycode@>=0.2.0",
+                      "resolved": "https://npm.webfilings.org/punycode/-/punycode-1.3.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@~0.10.0",
+                  "resolved": "https://npm.webfilings.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://npm.webfilings.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://npm.webfilings.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://npm.webfilings.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@~0.4.0",
+                  "resolved": "https://npm.webfilings.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://npm.webfilings.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x",
+                      "resolved": "https://npm.webfilings.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x",
+                      "resolved": "https://npm.webfilings.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x",
+                      "resolved": "https://npm.webfilings.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x",
+                      "resolved": "https://npm.webfilings.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0",
+                  "resolved": "https://npm.webfilings.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "https://npm.webfilings.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@~2.3.3",
+              "resolved": "https://npm.webfilings.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            },
+            "vargs": {
+              "version": "0.1.0",
+              "from": "vargs@~0.1.0",
+              "resolved": "https://registry.npmjs.org/vargs/-/vargs-0.1.0.tgz"
+            }
+          }
+        },
+        "sauce-connect-launcher": {
+          "version": "0.6.1",
+          "from": "sauce-connect-launcher@~0.6.0",
+          "resolved": "https://npm.webfilings.org/sauce-connect-launcher/-/sauce-connect-launcher-0.6.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@~0.9.0",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+            },
+            "adm-zip": {
+              "version": "0.4.7",
+              "from": "adm-zip@~0.4.3",
+              "resolved": "https://npm.webfilings.org/adm-zip/-/adm-zip-0.4.7.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@~2.2.6",
+              "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@~0.9.6",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "saucelabs@~0.1.0",
+          "resolved": "https://npm.webfilings.org/saucelabs/-/saucelabs-0.1.1.tgz"
+        }
+      }
+    },
+    "lodash": {
+      "version": "2.4.1",
+      "from": "lodash@^2.4.1",
+      "resolved": "https://npm.webfilings.org/lodash/-/lodash-2.4.1.tgz"
+    },
+    "merge-stream": {
+      "version": "0.1.7",
+      "from": "merge-stream@^0.1.5",
+      "resolved": "https://npm.webfilings.org/merge-stream/-/merge-stream-0.1.7.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6.3",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.0",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "from": "mkdirp@^0.5.0",
+      "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://npm.webfilings.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "open": {
+      "version": "0.0.5",
+      "from": "open@0.0.5",
+      "resolved": "https://npm.webfilings.org/open/-/open-0.0.5.tgz"
+    },
+    "partialify": {
+      "version": "3.1.3",
+      "from": "partialify@^3.1.1",
+      "resolved": "https://npm.webfilings.org/partialify/-/partialify-3.1.3.tgz",
+      "dependencies": {
+        "string-to-js": {
+          "version": "0.0.1",
+          "from": "string-to-js@0.0.1",
+          "resolved": "https://npm.webfilings.org/string-to-js/-/string-to-js-0.0.1.tgz"
+        },
+        "through": {
+          "version": "2.3.6",
+          "from": "through@~2.3.1",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+        }
+      }
+    },
+    "phantomjs": {
+      "version": "1.9.15",
+      "from": "phantomjs@1.9.15",
+      "resolved": "https://npm.webfilings.org/phantomjs/-/phantomjs-1.9.15.tgz",
+      "dependencies": {
+        "adm-zip": {
+          "version": "0.4.4",
+          "from": "adm-zip@0.4.4",
+          "resolved": "https://npm.webfilings.org/adm-zip/-/adm-zip-0.4.4.tgz"
+        },
+        "fs-extra": {
+          "version": "0.16.5",
+          "from": "fs-extra@~0.16.0",
+          "resolved": "https://npm.webfilings.org/fs-extra/-/fs-extra-0.16.5.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.5",
+              "from": "graceful-fs@^3.0.5",
+              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+            },
+            "jsonfile": {
+              "version": "2.0.0",
+              "from": "jsonfile@^2.0.0",
+              "resolved": "https://npm.webfilings.org/jsonfile/-/jsonfile-2.0.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.3.1",
+              "from": "rimraf@^2.2.8",
+              "resolved": "https://npm.webfilings.org/rimraf/-/rimraf-2.3.1.tgz"
+            }
+          }
+        },
+        "kew": {
+          "version": "0.4.0",
+          "from": "kew@0.4.0",
+          "resolved": "https://npm.webfilings.org/kew/-/kew-0.4.0.tgz"
+        },
+        "npmconf": {
+          "version": "2.0.9",
+          "from": "npmconf@2.0.9",
+          "resolved": "https://npm.webfilings.org/npmconf/-/npmconf-2.0.9.tgz",
+          "dependencies": {
+            "config-chain": {
+              "version": "1.1.8",
+              "from": "config-chain@~1.1.8",
+              "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+              "dependencies": {
+                "proto-list": {
+                  "version": "1.2.3",
+                  "from": "proto-list@~1.2.1",
+                  "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@~2.0.1",
+              "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "ini": {
+              "version": "1.3.3",
+              "from": "ini@^1.2.0",
+              "resolved": "https://npm.webfilings.org/ini/-/ini-1.3.3.tgz"
+            },
+            "nopt": {
+              "version": "3.0.1",
+              "from": "nopt@~3.0.1",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@1",
+                  "resolved": "https://npm.webfilings.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@~1.3.0",
+              "resolved": "https://npm.webfilings.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://npm.webfilings.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.0",
+              "from": "osenv@^0.1.0",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.0.tgz"
+            },
+            "semver": {
+              "version": "4.3.1",
+              "from": "semver@2 || 3 || 4",
+              "resolved": "https://npm.webfilings.org/semver/-/semver-4.3.1.tgz"
+            },
+            "uid-number": {
+              "version": "0.0.5",
+              "from": "uid-number@0.0.5",
+              "resolved": "https://npm.webfilings.org/uid-number/-/uid-number-0.0.5.tgz"
+            }
+          }
+        },
+        "progress": {
+          "version": "1.1.8",
+          "from": "progress@1.1.8",
+          "resolved": "https://npm.webfilings.org/progress/-/progress-1.1.8.tgz"
+        },
+        "request": {
+          "version": "2.42.0",
+          "from": "request@2.42.0",
+          "resolved": "https://npm.webfilings.org/request/-/request-2.42.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "bl@~0.9.0",
+              "resolved": "https://npm.webfilings.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@~1.0.26",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.6.0",
+              "from": "caseless@~0.6.0",
+              "resolved": "https://npm.webfilings.org/caseless/-/caseless-0.6.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "forever-agent@~0.5.0",
+              "resolved": "https://npm.webfilings.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "qs": {
+              "version": "1.2.2",
+              "from": "qs@~1.2.0",
+              "resolved": "https://npm.webfilings.org/qs/-/qs-1.2.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.0",
+              "from": "json-stringify-safe@~5.0.0",
+              "resolved": "https://npm.webfilings.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "mime-types@~1.0.1",
+              "resolved": "https://npm.webfilings.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "node-uuid@~1.4.0",
+              "resolved": "https://npm.webfilings.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "tunnel-agent@~0.4.0",
+              "resolved": "https://npm.webfilings.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "tough-cookie@>=0.12.0",
+              "resolved": "https://npm.webfilings.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=0.2.0",
+                  "resolved": "https://npm.webfilings.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "form-data@~0.1.0",
+              "resolved": "https://npm.webfilings.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.4",
+                  "resolved": "https://npm.webfilings.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://npm.webfilings.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.11",
+                  "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.0",
+                  "from": "async@~0.9.0",
+                  "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "http-signature@~0.10.0",
+              "resolved": "https://npm.webfilings.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "assert-plus@^0.1.5",
+                  "resolved": "https://npm.webfilings.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "asn1@0.1.11",
+                  "resolved": "https://npm.webfilings.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "ctype@0.5.3",
+                  "resolved": "https://npm.webfilings.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.4.0",
+              "from": "oauth-sign@~0.4.0",
+              "resolved": "https://npm.webfilings.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "hawk@1.1.1",
+              "resolved": "https://npm.webfilings.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "hoek@0.9.x",
+                  "resolved": "https://npm.webfilings.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "boom@0.4.x",
+                  "resolved": "https://npm.webfilings.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "cryptiles@0.2.x",
+                  "resolved": "https://npm.webfilings.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "sntp@0.2.x",
+                  "resolved": "https://npm.webfilings.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "aws-sign2@~0.5.0",
+              "resolved": "https://npm.webfilings.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "stringstream@~0.0.4",
+              "resolved": "https://npm.webfilings.org/stringstream/-/stringstream-0.0.4.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "request-progress@0.3.1",
+          "resolved": "https://npm.webfilings.org/request-progress/-/request-progress-0.3.1.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "throttleit@~0.0.2",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@~1.0.5",
+          "resolved": "https://npm.webfilings.org/which/-/which-1.0.9.tgz"
+        }
+      }
+    },
+    "react": {
+      "version": "0.12.2",
+      "from": "react@^0.12.1",
+      "resolved": "https://npm.webfilings.org/react/-/react-0.12.2.tgz",
+      "dependencies": {
+        "envify": {
+          "version": "3.3.0",
+          "from": "envify@^3.0.0",
+          "resolved": "https://npm.webfilings.org/envify/-/envify-3.3.0.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.4",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "jstransform": {
+              "version": "10.1.0",
+              "from": "jstransform@^10.0.1",
+              "resolved": "https://npm.webfilings.org/jstransform/-/jstransform-10.1.0.tgz",
+              "dependencies": {
+                "base62": {
+                  "version": "0.1.1",
+                  "from": "base62@0.1.1",
+                  "resolved": "https://npm.webfilings.org/base62/-/base62-0.1.1.tgz"
+                },
+                "esprima-fb": {
+                  "version": "13001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+                  "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.31",
+                  "from": "source-map@0.1.31",
+                  "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.31.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "requirejs": {
+      "version": "2.1.16",
+      "from": "requirejs@^2.1.14",
+      "resolved": "https://npm.webfilings.org/requirejs/-/requirejs-2.1.16.tgz"
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "from": "source-map@^0.1.33",
+      "resolved": "https://npm.webfilings.org/source-map/-/source-map-0.1.43.tgz",
+      "dependencies": {
+        "amdefine": {
+          "version": "0.1.0",
+          "from": "amdefine@>=0.0.4",
+          "resolved": "https://npm.webfilings.org/amdefine/-/amdefine-0.1.0.tgz"
+        }
+      }
+    },
+    "tiny-lr": {
+      "version": "0.0.7",
+      "from": "tiny-lr@0.0.7",
+      "resolved": "https://npm.webfilings.org/tiny-lr/-/tiny-lr-0.0.7.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "0.5.6",
+          "from": "qs@~0.5.2",
+          "resolved": "https://npm.webfilings.org/qs/-/qs-0.5.6.tgz"
+        },
+        "faye-websocket": {
+          "version": "0.4.4",
+          "from": "faye-websocket@~0.4.3",
+          "resolved": "https://npm.webfilings.org/faye-websocket/-/faye-websocket-0.4.4.tgz"
+        },
+        "noptify": {
+          "version": "0.0.3",
+          "from": "noptify@~0.0.3",
+          "resolved": "https://npm.webfilings.org/noptify/-/noptify-0.0.3.tgz",
+          "dependencies": {
+            "nopt": {
+              "version": "2.0.0",
+              "from": "nopt@~2.0.0",
+              "resolved": "https://npm.webfilings.org/nopt/-/nopt-2.0.0.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.5",
+                  "from": "abbrev@1",
+                  "resolved": "https://npm.webfilings.org/abbrev/-/abbrev-1.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@~0.8.0",
+          "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.1.tgz"
+        }
+      }
+    },
+    "typescript": {
+      "version": "1.4.1",
+      "from": "typescript@^1.4.1",
+      "resolved": "https://npm.webfilings.org/typescript/-/typescript-1.4.1.tgz"
+    },
+    "vinyl-source-stream": {
+      "version": "1.1.0",
+      "from": "vinyl-source-stream@^1.0.0",
+      "resolved": "https://npm.webfilings.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
+      "dependencies": {
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@^0.4.3",
+          "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "from": "clone@^0.2.0",
+              "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@^0.0.1",
+              "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@>=0.6.1 <1.0.0-0",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "yargs": {
+      "version": "1.3.3",
+      "from": "yargs@^1.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
+    }
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -59,7 +59,7 @@
             "jsonparse": {
               "version": "0.0.5",
               "from": "jsonparse@0.0.5",
-              "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
             },
             "through": {
               "version": "2.3.6",
@@ -112,21 +112,7 @@
             "through2": {
               "version": "0.5.1",
               "from": "through2@~0.5.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
@@ -162,7 +148,7 @@
             "base64-js": {
               "version": "0.0.7",
               "from": "base64-js@0.0.7",
-              "resolved": "https://npm.webfilings.org/base64-js/-/base64-js-0.0.7.tgz"
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
             },
             "ieee754": {
               "version": "1.1.4",
@@ -184,7 +170,7 @@
         "commondir": {
           "version": "0.0.1",
           "from": "commondir@0.0.1",
-          "resolved": "https://npm.webfilings.org/commondir/-/commondir-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
         },
         "concat-stream": {
           "version": "1.4.7",
@@ -195,6 +181,18 @@
               "version": "0.0.6",
               "from": "typedarray@~0.0.5",
               "resolved": "https://npm.webfilings.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@~1.1.9",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
             }
           }
         },
@@ -228,7 +226,7 @@
             "browserify-sign": {
               "version": "2.8.0",
               "from": "browserify-sign@2.8.0",
-              "resolved": "https://npm.webfilings.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
+              "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-2.8.0.tgz",
               "dependencies": {
                 "bn.js": {
                   "version": "1.3.0",
@@ -282,7 +280,7 @@
                     "pemstrip": {
                       "version": "0.0.1",
                       "from": "pemstrip@0.0.1",
-                      "resolved": "https://npm.webfilings.org/pemstrip/-/pemstrip-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/pemstrip/-/pemstrip-0.0.1.tgz"
                     }
                   }
                 }
@@ -434,21 +432,7 @@
             "through2": {
               "version": "0.5.1",
               "from": "through2@~0.5.1",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz"
             }
           }
         },
@@ -460,7 +444,21 @@
         "duplexer2": {
           "version": "0.0.2",
           "from": "duplexer2@~0.0.2",
-          "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@~1.1.9",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                }
+              }
+            }
+          }
         },
         "events": {
           "version": "1.0.2",
@@ -502,7 +500,7 @@
                 "jsonparse": {
                   "version": "0.0.5",
                   "from": "jsonparse@0.0.5",
-                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 }
               }
             },
@@ -571,7 +569,7 @@
         "isarray": {
           "version": "0.0.1",
           "from": "isarray@0.0.1",
-          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "labeled-stream-splicer": {
           "version": "1.0.2",
@@ -585,7 +583,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@^1.1.13-1",
+                  "from": "readable-stream@~1.1.9",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -603,7 +601,7 @@
                 "indexof": {
                   "version": "0.0.1",
                   "from": "indexof@0.0.1",
-                  "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             }
@@ -622,7 +620,7 @@
                 "jsonparse": {
                   "version": "0.0.5",
                   "from": "jsonparse@0.0.5",
-                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
@@ -734,18 +732,6 @@
                   "from": "through2@~0.5.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
                   "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        }
-                      }
-                    },
                     "xtend": {
                       "version": "3.0.0",
                       "from": "xtend@~3.0.0",
@@ -758,7 +744,7 @@
             "subarg": {
               "version": "0.0.1",
               "from": "subarg@0.0.1",
-              "resolved": "https://npm.webfilings.org/subarg/-/subarg-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
@@ -772,18 +758,6 @@
               "from": "through2@~0.4.1",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@~1.0.17",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    }
-                  }
-                },
                 "xtend": {
                   "version": "2.1.2",
                   "from": "xtend@~2.1.1",
@@ -843,19 +817,14 @@
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
-          "version": "1.1.10",
+          "version": "1.0.33",
           "from": "readable-stream@^1.0.33-1",
-          "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+          "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
               "from": "core-util-is@~1.0.0",
               "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-            },
-            "debuglog": {
-              "version": "0.0.2",
-              "from": "debuglog@0.0.2",
-              "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
             }
           }
         },
@@ -867,7 +836,7 @@
         "shallow-copy": {
           "version": "0.0.1",
           "from": "shallow-copy@0.0.1",
-          "resolved": "https://npm.webfilings.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
         },
         "shasum": {
           "version": "1.0.1",
@@ -939,7 +908,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.1.13",
-              "from": "readable-stream@>=1.1.13-1 <1.2.0-0",
+              "from": "readable-stream@~1.1.9",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -1029,7 +998,7 @@
             "uglify-js": {
               "version": "2.4.16",
               "from": "uglify-js@~2.4.0",
-              "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
@@ -1082,7 +1051,7 @@
             "querystring": {
               "version": "0.2.0",
               "from": "querystring@0.2.0",
-              "resolved": "https://npm.webfilings.org/querystring/-/querystring-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
@@ -1099,7 +1068,7 @@
             "indexof": {
               "version": "0.0.1",
               "from": "indexof@0.0.1",
-              "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
         },
@@ -1132,7 +1101,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "0.2.1",
-              "from": "ansi-regex@^0.2.0",
+              "from": "ansi-regex@^0.2.1",
               "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
             }
           }
@@ -1298,7 +1267,7 @@
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "concat-map@0.0.1",
-                  "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -1335,7 +1304,7 @@
         },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@>=3.0.0 <4.0.0-0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -1541,22 +1510,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -1572,7 +1551,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "through2": {
               "version": "0.6.3",
@@ -1592,7 +1571,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -1692,7 +1671,7 @@
                             "concat-map": {
                               "version": "0.0.1",
                               "from": "concat-map@0.0.1",
-                              "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
                         }
@@ -1834,7 +1813,7 @@
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -1964,7 +1943,328 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.0",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-bump": {
+      "version": "0.1.13",
+      "from": "gulp-bump@^0.1.7",
+      "resolved": "https://npm.webfilings.org/gulp-bump/-/gulp-bump-0.1.13.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "through2": {
+              "version": "0.6.3",
+              "from": "through2@^0.6.3",
+              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -2003,17 +2303,61 @@
               }
             }
           }
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@^2.3.2",
+          "resolved": "https://npm.webfilings.org/semver/-/semver-2.3.2.tgz"
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@^0.5.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.17",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@~3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            }
+          }
         }
       }
     },
-    "gulp-bump": {
-      "version": "0.1.13",
-      "from": "gulp-bump@^0.1.7",
-      "resolved": "https://npm.webfilings.org/gulp-bump/-/gulp-bump-0.1.13.tgz",
+    "gulp-changed": {
+      "version": "1.1.1",
+      "from": "gulp-changed@^1.0.0",
+      "resolved": "https://npm.webfilings.org/gulp-changed/-/gulp-changed-1.1.1.tgz",
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@~3.0.3",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -2224,22 +2568,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -2255,362 +2609,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "through2": {
-              "version": "0.6.3",
-              "from": "through2@^0.6.3",
-              "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
-              "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                    }
-                  }
-                },
-                "xtend": {
-                  "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                }
-              }
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@^0.4.3",
-              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@^0.2.0",
-                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@^0.0.1",
-                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "semver": {
-          "version": "2.3.2",
-          "from": "semver@^2.3.2",
-          "resolved": "https://npm.webfilings.org/semver/-/semver-2.3.2.tgz"
-        },
-        "through2": {
-          "version": "0.5.1",
-          "from": "through2@^0.5.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@1.0.33",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "3.0.0",
-              "from": "xtend@~3.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-changed": {
-      "version": "1.1.1",
-      "from": "gulp-changed@^1.0.0",
-      "resolved": "https://npm.webfilings.org/gulp-changed/-/gulp-changed-1.1.1.tgz",
-      "dependencies": {
-        "gulp-util": {
-          "version": "3.0.4",
-          "from": "gulp-util@^3.0.1",
-          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
-              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "array-uniq@^1.0.2",
-              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
-            },
-            "beeper": {
-              "version": "1.0.0",
-              "from": "beeper@^1.0.0",
-              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
-                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
-                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.0",
-                  "from": "supports-color@^1.3.0",
-                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "dateformat@^1.0.11",
-              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
-                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "meow@*",
-                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2",
-                          "from": "camelcase@^1.0.1",
-                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0",
-                          "from": "map-obj@^1.0.0",
-                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "from": "repeating@^1.1.0",
-                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0",
-                              "from": "is-finite@^1.0.0",
-                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "lodash._reescape@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "lodash._reevaluate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "lodash._reinterpolate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            },
-            "lodash.template": {
-              "version": "3.3.2",
-              "from": "lodash.template@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._basecopy@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "lodash._basetostring@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "lodash._basevalues@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.4",
-                  "from": "lodash._isiterateecall@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "lodash.escape@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.0.4",
-                  "from": "lodash.keys@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarguments@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarray@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
-                    },
-                    "lodash.isnative": {
-                      "version": "3.0.0",
-                      "from": "lodash.isnative@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "lodash.templatesettings@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.0",
-              "from": "minimist@^1.1.0",
-              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "multipipe@^0.1.2",
-              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.10",
-                      "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "object-assign@^2.0.0",
-              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -2633,7 +2632,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@~0.6.3",
+          "from": "through2@~0.6",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -2649,7 +2648,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -2741,7 +2740,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -2895,22 +2894,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -2926,7 +2935,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -2954,7 +2963,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.1",
+          "from": "through2@^0.6.3",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -2970,7 +2979,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3216,22 +3225,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -3247,7 +3266,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -3286,7 +3305,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3340,7 +3359,700 @@
         },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0",
+          "from": "gulp-util@~3.0.3",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-connect": {
+      "version": "2.2.0",
+      "from": "gulp-connect@^2.0.5",
+      "resolved": "https://npm.webfilings.org/gulp-connect/-/gulp-connect-2.2.0.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.1.7",
+          "from": "event-stream@~3.1.0",
+          "resolved": "https://npm.webfilings.org/event-stream/-/event-stream-3.1.7.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.6",
+              "from": "through@~2.3.1",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@~0.1.1",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@~0",
+              "resolved": "https://npm.webfilings.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@~0.1.0",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.2.10",
+              "from": "split@0.2",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@~0.0.4",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.3.2",
+          "from": "connect-livereload@~0.3.2",
+          "resolved": "https://npm.webfilings.org/connect-livereload/-/connect-livereload-0.3.2.tgz"
+        },
+        "connect": {
+          "version": "2.17.3",
+          "from": "connect@<2.18.0",
+          "resolved": "https://npm.webfilings.org/connect/-/connect-2.17.3.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.2.2",
+              "from": "body-parser@1.2.2",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.2.2.tgz",
+              "dependencies": {
+                "raw-body": {
+                  "version": "1.1.6",
+                  "from": "raw-body@1.1.6",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.6.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.1.0",
+              "from": "cookie-parser@1.1.0",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.1.0.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.3",
+              "from": "cookie-signature@1.0.3",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
+            },
+            "compression": {
+              "version": "1.0.2",
+              "from": "compression@1.0.2",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.0.2.tgz",
+              "dependencies": {
+                "bytes": {
+                  "version": "0.3.0",
+                  "from": "bytes@0.3.0",
+                  "resolved": "https://npm.webfilings.org/bytes/-/bytes-0.3.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.3",
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
+                },
+                "compressible": {
+                  "version": "1.0.1",
+                  "from": "compressible@1.0.1",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-1.0.1.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.1.0",
+              "from": "connect-timeout@1.1.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.1.0.tgz"
+            },
+            "csurf": {
+              "version": "1.2.0",
+              "from": "csurf@1.2.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.2.0.tgz",
+              "dependencies": {
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "uid2@~0.0.2",
+                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
+                },
+                "scmp": {
+                  "version": "0.0.3",
+                  "from": "scmp@~0.0.3",
+                  "resolved": "https://npm.webfilings.org/scmp/-/scmp-0.0.3.tgz"
+                }
+              }
+            },
+            "errorhandler": {
+              "version": "1.0.1",
+              "from": "errorhandler@1.0.1",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.0.1.tgz"
+            },
+            "express-session": {
+              "version": "1.2.1",
+              "from": "express-session@1.2.1",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.2.1.tgz",
+              "dependencies": {
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                },
+                "uid2": {
+                  "version": "0.0.3",
+                  "from": "uid2@0.0.3",
+                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
+                },
+                "buffer-crc32": {
+                  "version": "0.2.1",
+                  "from": "buffer-crc32@0.2.1",
+                  "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.2",
+              "from": "fresh@0.2.2",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz"
+            },
+            "method-override": {
+              "version": "1.0.2",
+              "from": "method-override@1.0.2",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-1.0.2.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.0.0",
+                  "from": "methods@1.0.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.0.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.1.1",
+              "from": "morgan@1.1.1",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.1.1.tgz"
+            },
+            "on-headers": {
+              "version": "0.0.0",
+              "from": "on-headers@0.0.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-0.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.0.1",
+              "from": "parseurl@1.0.1",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.0.1.tgz"
+            },
+            "qs": {
+              "version": "0.6.6",
+              "from": "qs@0.6.6",
+              "resolved": "https://npm.webfilings.org/qs/-/qs-0.6.6.tgz"
+            },
+            "response-time": {
+              "version": "1.0.0",
+              "from": "response-time@1.0.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-1.0.0.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.0.0",
+              "from": "serve-favicon@2.0.0",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.0.0.tgz"
+            },
+            "serve-index": {
+              "version": "1.0.3",
+              "from": "serve-index@1.0.3",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.0.3.tgz",
+              "dependencies": {
+                "batch": {
+                  "version": "0.5.0",
+                  "from": "batch@0.5.0",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.0.tgz"
+                },
+                "negotiator": {
+                  "version": "0.4.3",
+                  "from": "negotiator@0.4.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.3.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.1.0",
+              "from": "serve-static@1.1.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.1.0.tgz",
+              "dependencies": {
+                "send": {
+                  "version": "0.3.0",
+                  "from": "send@0.3.0",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.3.0.tgz",
+                  "dependencies": {
+                    "buffer-crc32": {
+                      "version": "0.2.1",
+                      "from": "buffer-crc32@0.2.1",
+                      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.8.0",
+                      "from": "debug@0.8.0",
+                      "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.0.tgz"
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@1.2.11",
+                      "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/range-parser/-/range-parser-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.2.0",
+              "from": "type-is@1.2.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.2.0.tgz",
+              "dependencies": {
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@1.2.11",
+                  "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
+                }
+              }
+            },
+            "vhost": {
+              "version": "1.0.0",
+              "from": "vhost@1.0.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-1.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            },
+            "debug": {
+              "version": "0.8.1",
+              "from": "debug@>= 0.8.0 < 1",
+              "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.1.tgz"
+            },
+            "multiparty": {
+              "version": "2.2.0",
+              "from": "multiparty@2.2.0",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-2.2.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@~1.1.9",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@~0.2.0",
+                  "resolved": "https://npm.webfilings.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-flatten": {
+      "version": "0.0.4",
+      "from": "gulp-flatten@^0.0.4",
+      "resolved": "https://npm.webfilings.org/gulp-flatten/-/gulp-flatten-0.0.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@^0.6.1",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@^3.0.1",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -3551,22 +4263,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -3582,7 +4304,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -3602,15 +4324,27 @@
               }
             }
           }
+        }
+      }
+    },
+    "gulp-header": {
+      "version": "1.2.2",
+      "from": "gulp-header@^1.0.5",
+      "resolved": "https://npm.webfilings.org/gulp-header/-/gulp-header-1.2.2.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@*",
+          "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@~0.6",
+          "from": "through2@~0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "readable-stream@~1.0.17",
               "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -3621,7 +4355,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -3644,376 +4378,14 @@
         }
       }
     },
-    "gulp-connect": {
-      "version": "2.2.0",
-      "from": "gulp-connect@^2.0.5",
-      "resolved": "https://npm.webfilings.org/gulp-connect/-/gulp-connect-2.2.0.tgz",
+    "gulp-istanbul": {
+      "version": "0.3.1",
+      "from": "gulp-istanbul@^0.3.1",
+      "resolved": "https://npm.webfilings.org/gulp-istanbul/-/gulp-istanbul-0.3.1.tgz",
       "dependencies": {
-        "event-stream": {
-          "version": "3.1.7",
-          "from": "event-stream@~3.1.0",
-          "resolved": "https://npm.webfilings.org/event-stream/-/event-stream-3.1.7.tgz",
-          "dependencies": {
-            "through": {
-              "version": "2.3.6",
-              "from": "through@~2.3.1",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
-            },
-            "duplexer": {
-              "version": "0.1.1",
-              "from": "duplexer@~0.1.1",
-              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            },
-            "from": {
-              "version": "0.1.3",
-              "from": "from@~0",
-              "resolved": "https://npm.webfilings.org/from/-/from-0.1.3.tgz"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "from": "map-stream@~0.1.0",
-              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
-            },
-            "pause-stream": {
-              "version": "0.0.11",
-              "from": "pause-stream@0.0.11",
-              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
-            },
-            "split": {
-              "version": "0.2.10",
-              "from": "split@0.2",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz"
-            },
-            "stream-combiner": {
-              "version": "0.0.4",
-              "from": "stream-combiner@~0.0.4",
-              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-            }
-          }
-        },
-        "connect-livereload": {
-          "version": "0.3.2",
-          "from": "connect-livereload@~0.3.2",
-          "resolved": "https://npm.webfilings.org/connect-livereload/-/connect-livereload-0.3.2.tgz"
-        },
-        "connect": {
-          "version": "2.17.3",
-          "from": "connect@<2.18.0",
-          "resolved": "https://npm.webfilings.org/connect/-/connect-2.17.3.tgz",
-          "dependencies": {
-            "basic-auth-connect": {
-              "version": "1.0.0",
-              "from": "basic-auth-connect@1.0.0",
-              "resolved": "https://npm.webfilings.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
-            },
-            "body-parser": {
-              "version": "1.2.2",
-              "from": "body-parser@1.2.2",
-              "resolved": "https://npm.webfilings.org/body-parser/-/body-parser-1.2.2.tgz",
-              "dependencies": {
-                "raw-body": {
-                  "version": "1.1.6",
-                  "from": "raw-body@1.1.6",
-                  "resolved": "https://npm.webfilings.org/raw-body/-/raw-body-1.1.6.tgz"
-                }
-              }
-            },
-            "bytes": {
-              "version": "1.0.0",
-              "from": "bytes@1.0.0",
-              "resolved": "https://npm.webfilings.org/bytes/-/bytes-1.0.0.tgz"
-            },
-            "cookie": {
-              "version": "0.1.2",
-              "from": "cookie@0.1.2",
-              "resolved": "https://npm.webfilings.org/cookie/-/cookie-0.1.2.tgz"
-            },
-            "cookie-parser": {
-              "version": "1.1.0",
-              "from": "cookie-parser@1.1.0",
-              "resolved": "https://npm.webfilings.org/cookie-parser/-/cookie-parser-1.1.0.tgz"
-            },
-            "cookie-signature": {
-              "version": "1.0.3",
-              "from": "cookie-signature@1.0.3",
-              "resolved": "https://npm.webfilings.org/cookie-signature/-/cookie-signature-1.0.3.tgz"
-            },
-            "compression": {
-              "version": "1.0.2",
-              "from": "compression@1.0.2",
-              "resolved": "https://npm.webfilings.org/compression/-/compression-1.0.2.tgz",
-              "dependencies": {
-                "bytes": {
-                  "version": "0.3.0",
-                  "from": "bytes@0.3.0",
-                  "resolved": "https://npm.webfilings.org/bytes/-/bytes-0.3.0.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.3",
-                  "from": "negotiator@0.4.3",
-                  "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.3.tgz"
-                },
-                "compressible": {
-                  "version": "1.0.1",
-                  "from": "compressible@1.0.1",
-                  "resolved": "https://npm.webfilings.org/compressible/-/compressible-1.0.1.tgz"
-                }
-              }
-            },
-            "connect-timeout": {
-              "version": "1.1.0",
-              "from": "connect-timeout@1.1.0",
-              "resolved": "https://npm.webfilings.org/connect-timeout/-/connect-timeout-1.1.0.tgz"
-            },
-            "csurf": {
-              "version": "1.2.0",
-              "from": "csurf@1.2.0",
-              "resolved": "https://npm.webfilings.org/csurf/-/csurf-1.2.0.tgz",
-              "dependencies": {
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "uid2@0.0.3",
-                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "scmp": {
-                  "version": "0.0.3",
-                  "from": "scmp@~0.0.3",
-                  "resolved": "https://npm.webfilings.org/scmp/-/scmp-0.0.3.tgz"
-                }
-              }
-            },
-            "errorhandler": {
-              "version": "1.0.1",
-              "from": "errorhandler@1.0.1",
-              "resolved": "https://npm.webfilings.org/errorhandler/-/errorhandler-1.0.1.tgz"
-            },
-            "express-session": {
-              "version": "1.2.1",
-              "from": "express-session@1.2.1",
-              "resolved": "https://npm.webfilings.org/express-session/-/express-session-1.2.1.tgz",
-              "dependencies": {
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
-                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                },
-                "uid2": {
-                  "version": "0.0.3",
-                  "from": "uid2@0.0.3",
-                  "resolved": "https://npm.webfilings.org/uid2/-/uid2-0.0.3.tgz"
-                },
-                "buffer-crc32": {
-                  "version": "0.2.1",
-                  "from": "buffer-crc32@0.2.1",
-                  "resolved": "https://npm.webfilings.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-                }
-              }
-            },
-            "fresh": {
-              "version": "0.2.2",
-              "from": "fresh@0.2.2",
-              "resolved": "https://npm.webfilings.org/fresh/-/fresh-0.2.2.tgz"
-            },
-            "method-override": {
-              "version": "1.0.2",
-              "from": "method-override@1.0.2",
-              "resolved": "https://npm.webfilings.org/method-override/-/method-override-1.0.2.tgz",
-              "dependencies": {
-                "methods": {
-                  "version": "1.0.0",
-                  "from": "methods@1.0.0",
-                  "resolved": "https://npm.webfilings.org/methods/-/methods-1.0.0.tgz"
-                }
-              }
-            },
-            "morgan": {
-              "version": "1.1.1",
-              "from": "morgan@1.1.1",
-              "resolved": "https://npm.webfilings.org/morgan/-/morgan-1.1.1.tgz"
-            },
-            "on-headers": {
-              "version": "0.0.0",
-              "from": "on-headers@0.0.0",
-              "resolved": "https://npm.webfilings.org/on-headers/-/on-headers-0.0.0.tgz"
-            },
-            "parseurl": {
-              "version": "1.0.1",
-              "from": "parseurl@1.0.1",
-              "resolved": "https://npm.webfilings.org/parseurl/-/parseurl-1.0.1.tgz"
-            },
-            "qs": {
-              "version": "0.6.6",
-              "from": "qs@0.6.6",
-              "resolved": "https://npm.webfilings.org/qs/-/qs-0.6.6.tgz"
-            },
-            "response-time": {
-              "version": "1.0.0",
-              "from": "response-time@1.0.0",
-              "resolved": "https://npm.webfilings.org/response-time/-/response-time-1.0.0.tgz"
-            },
-            "serve-favicon": {
-              "version": "2.0.0",
-              "from": "serve-favicon@2.0.0",
-              "resolved": "https://npm.webfilings.org/serve-favicon/-/serve-favicon-2.0.0.tgz"
-            },
-            "serve-index": {
-              "version": "1.0.3",
-              "from": "serve-index@1.0.3",
-              "resolved": "https://npm.webfilings.org/serve-index/-/serve-index-1.0.3.tgz",
-              "dependencies": {
-                "batch": {
-                  "version": "0.5.0",
-                  "from": "batch@0.5.0",
-                  "resolved": "https://npm.webfilings.org/batch/-/batch-0.5.0.tgz"
-                },
-                "negotiator": {
-                  "version": "0.4.3",
-                  "from": "negotiator@0.4.3",
-                  "resolved": "https://npm.webfilings.org/negotiator/-/negotiator-0.4.3.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.1.0",
-              "from": "serve-static@1.1.0",
-              "resolved": "https://npm.webfilings.org/serve-static/-/serve-static-1.1.0.tgz",
-              "dependencies": {
-                "send": {
-                  "version": "0.3.0",
-                  "from": "send@0.3.0",
-                  "resolved": "https://npm.webfilings.org/send/-/send-0.3.0.tgz",
-                  "dependencies": {
-                    "buffer-crc32": {
-                      "version": "0.2.1",
-                      "from": "buffer-crc32@0.2.1",
-                      "resolved": "https://npm.webfilings.org/buffer-crc32/-/buffer-crc32-0.2.1.tgz"
-                    },
-                    "debug": {
-                      "version": "0.8.0",
-                      "from": "debug@0.8.0",
-                      "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.0.tgz"
-                    },
-                    "mime": {
-                      "version": "1.2.11",
-                      "from": "mime@1.2.11",
-                      "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
-                    },
-                    "range-parser": {
-                      "version": "1.0.2",
-                      "from": "range-parser@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/range-parser/-/range-parser-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "type-is": {
-              "version": "1.2.0",
-              "from": "type-is@1.2.0",
-              "resolved": "https://npm.webfilings.org/type-is/-/type-is-1.2.0.tgz",
-              "dependencies": {
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@1.2.11",
-                  "resolved": "https://npm.webfilings.org/mime/-/mime-1.2.11.tgz"
-                }
-              }
-            },
-            "vhost": {
-              "version": "1.0.0",
-              "from": "vhost@1.0.0",
-              "resolved": "https://npm.webfilings.org/vhost/-/vhost-1.0.0.tgz"
-            },
-            "pause": {
-              "version": "0.0.1",
-              "from": "pause@0.0.1",
-              "resolved": "https://npm.webfilings.org/pause/-/pause-0.0.1.tgz"
-            },
-            "debug": {
-              "version": "0.8.1",
-              "from": "debug@>= 0.8.0 < 1",
-              "resolved": "https://npm.webfilings.org/debug/-/debug-0.8.1.tgz"
-            },
-            "multiparty": {
-              "version": "2.2.0",
-              "from": "multiparty@2.2.0",
-              "resolved": "https://npm.webfilings.org/multiparty/-/multiparty-2.2.0.tgz",
-              "dependencies": {
-                "stream-counter": {
-                  "version": "0.2.0",
-                  "from": "stream-counter@~0.2.0",
-                  "resolved": "https://npm.webfilings.org/stream-counter/-/stream-counter-0.2.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "1.1.10",
-                  "from": "readable-stream@~1.1.9",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                    },
-                    "debuglog": {
-                      "version": "0.0.2",
-                      "from": "debuglog@0.0.2",
-                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-flatten": {
-      "version": "0.0.4",
-      "from": "gulp-flatten@^0.0.4",
-      "resolved": "https://npm.webfilings.org/gulp-flatten/-/gulp-flatten-0.0.4.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.6.3",
-          "from": "through2@~0.6.3",
-          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.1",
+          "from": "gulp-util@^3.0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -4224,22 +4596,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -4255,330 +4637,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@^0.4.3",
-              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@^0.2.0",
-                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@^0.0.1",
-                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "gulp-header": {
-      "version": "1.2.2",
-      "from": "gulp-header@^1.0.5",
-      "resolved": "https://npm.webfilings.org/gulp-header/-/gulp-header-1.2.2.tgz",
-      "dependencies": {
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "object-assign@*",
-          "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
-        },
-        "through2": {
-          "version": "0.6.3",
-          "from": "through2@>=0.6.1 <1.0.0-0",
-          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-istanbul": {
-      "version": "0.3.1",
-      "from": "gulp-istanbul@^0.3.1",
-      "resolved": "https://npm.webfilings.org/gulp-istanbul/-/gulp-istanbul-0.3.1.tgz",
-      "dependencies": {
-        "gulp-util": {
-          "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
-          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
-              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "array-uniq@^1.0.2",
-              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
-            },
-            "beeper": {
-              "version": "1.0.0",
-              "from": "beeper@^1.0.0",
-              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
-                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
-                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@1.1.1",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.0",
-                  "from": "supports-color@^1.3.0",
-                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "dateformat@^1.0.11",
-              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@*",
-                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "meow@*",
-                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2",
-                          "from": "camelcase@^1.0.1",
-                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0",
-                          "from": "map-obj@^1.0.0",
-                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "from": "repeating@^1.1.0",
-                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0",
-                              "from": "is-finite@^1.0.0",
-                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "lodash._reescape@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "lodash._reevaluate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "lodash._reinterpolate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            },
-            "lodash.template": {
-              "version": "3.3.2",
-              "from": "lodash.template@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._basecopy@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "lodash._basetostring@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "lodash._basevalues@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.4",
-                  "from": "lodash._isiterateecall@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "lodash.escape@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.0.4",
-                  "from": "lodash.keys@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarguments@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarray@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
-                    },
-                    "lodash.isnative": {
-                      "version": "3.0.0",
-                      "from": "lodash.isnative@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "lodash.templatesettings@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.0",
-              "from": "minimist@^1.1.0",
-              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "multipipe@^0.1.2",
-              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.10",
-                      "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "object-assign@^2.0.0",
-              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "through2": {
               "version": "0.6.3",
@@ -4598,7 +4657,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -4827,7 +4886,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@1.0.33",
+              "from": "readable-stream@~1.0.17",
               "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -4838,7 +4897,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -4872,6 +4931,691 @@
       "version": "1.0.1",
       "from": "gulp-jasmine@^1.0.1",
       "resolved": "https://npm.webfilings.org/gulp-jasmine/-/gulp-jasmine-1.0.1.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "3.0.4",
+          "from": "gulp-util@~3.0.3",
+          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0",
+              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@^1.0.2",
+              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.0.0",
+              "from": "beeper@^1.0.0",
+              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
+            },
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@^1.0.0",
+              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@^1.0.2",
+                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1",
+                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@1.1.1",
+                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.0",
+                  "from": "supports-color@^1.3.0",
+                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@^1.0.11",
+              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.0.2",
+                          "from": "camelcase@^1.0.1",
+                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.0",
+                          "from": "map-obj@^1.0.0",
+                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@^1.1.0",
+                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@^1.1.0",
+                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.0",
+                              "from": "is-finite@^1.0.0",
+                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.3.2",
+              "from": "lodash.template@^3.0.0",
+              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._basecopy@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.0",
+                  "from": "lodash._basetostring@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.4",
+                  "from": "lodash._isiterateecall@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.0.4",
+                  "from": "lodash.keys@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarguments@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.0",
+                      "from": "lodash.isarray@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
+                    },
+                    "lodash.isnative": {
+                      "version": "3.0.0",
+                      "from": "lodash.isnative@^3.0.0",
+                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@^3.0.0",
+                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@^0.1.2",
+              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@^0.4.3",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@^0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minijasminenode2": {
+          "version": "1.0.0",
+          "from": "minijasminenode2@^1.0.0",
+          "resolved": "https://npm.webfilings.org/minijasminenode2/-/minijasminenode2-1.0.0.tgz",
+          "dependencies": {
+            "jasmine-core": {
+              "version": "2.0.0",
+              "from": "jasmine-core@2.0.0",
+              "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.0.0.tgz"
+            }
+          }
+        },
+        "require-uncached": {
+          "version": "1.0.2",
+          "from": "require-uncached@^1.0.2",
+          "resolved": "https://npm.webfilings.org/require-uncached/-/require-uncached-1.0.2.tgz",
+          "dependencies": {
+            "caller-path": {
+              "version": "0.1.0",
+              "from": "caller-path@^0.1.0",
+              "resolved": "https://npm.webfilings.org/caller-path/-/caller-path-0.1.0.tgz",
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "from": "callsites@^0.2.0",
+                  "resolved": "https://npm.webfilings.org/callsites/-/callsites-0.2.0.tgz"
+                }
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.0",
+              "from": "resolve-from@^1.0.0",
+              "resolved": "https://npm.webfilings.org/resolve-from/-/resolve-from-1.0.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@~0.6",
+          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-jsdoc": {
+      "version": "0.1.4",
+      "from": "gulp-jsdoc@^0.1.4",
+      "resolved": "https://npm.webfilings.org/gulp-jsdoc/-/gulp-jsdoc-0.1.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@~0.4.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.17",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@~2.1.1",
+              "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@~0.4.0",
+                  "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@~0.4.0",
+          "resolved": "https://npm.webfilings.org/chalk/-/chalk-0.4.0.tgz",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.7",
+              "from": "has-color@~0.1.0",
+              "resolved": "https://npm.webfilings.org/has-color/-/has-color-0.1.7.tgz"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "ansi-styles@~1.0.0",
+              "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "strip-ansi@~0.1.0",
+              "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@~0.2.0",
+          "resolved": "https://npm.webfilings.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "vinyl-fs": {
+          "version": "0.1.4",
+          "from": "vinyl-fs@~0.1.2",
+          "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.1.4.tgz",
+          "dependencies": {
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@^0.2.0",
+              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@~0.0.1",
+                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@^3.1.5",
+              "resolved": "https://npm.webfilings.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.1",
+                  "from": "minimatch@^2.0.1",
+                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@^1.0.0",
+                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@^0.2.0",
+                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@^0.1.0",
+                  "resolved": "https://npm.webfilings.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@^0.0.12",
+                  "resolved": "https://npm.webfilings.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@^0.1.1",
+                      "resolved": "https://npm.webfilings.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@^1.0.0",
+                  "resolved": "https://npm.webfilings.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                },
+                "through2": {
+                  "version": "0.6.3",
+                  "from": "through2@^0.6.1",
+                  "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@^0.0.6",
+              "resolved": "https://npm.webfilings.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@^0.5.1",
+                  "resolved": "https://npm.webfilings.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@~0.1.0",
+                      "resolved": "https://npm.webfilings.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.1",
+                          "from": "lodash@~1.0.1",
+                          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@~3.1.21",
+                          "resolved": "https://npm.webfilings.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@1",
+                              "resolved": "https://npm.webfilings.org/inherits/-/inherits-1.0.0.tgz"
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@~1.2.0",
+                              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@~0.2.11",
+                          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "sigmund": {
+                              "version": "1.0.0",
+                              "from": "sigmund@~1.0.0",
+                              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
+                            },
+                            "lru-cache": {
+                              "version": "2.5.0",
+                              "from": "lru-cache@2",
+                              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@^0.3.5",
+              "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@^2.0.1",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@^0.1.0",
+              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
+            }
+          }
+        },
+        "jsdoc": {
+          "version": "3.3.0-alpha5",
+          "from": "jsdoc@3.3.0-alpha5",
+          "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.3.0-alpha5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@~0.1.22",
+              "resolved": "https://npm.webfilings.org/async/-/async-0.1.22.tgz"
+            },
+            "catharsis": {
+              "version": "0.7.1",
+              "from": "catharsis@~0.7.0",
+              "resolved": "https://npm.webfilings.org/catharsis/-/catharsis-0.7.1.tgz"
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~1.0.4",
+              "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
+            },
+            "js2xmlparser": {
+              "version": "0.1.9",
+              "from": "js2xmlparser@~0.1.0",
+              "resolved": "https://npm.webfilings.org/js2xmlparser/-/js2xmlparser-0.1.9.tgz"
+            },
+            "taffydb": {
+              "version": "2.6.2",
+              "from": "https://github.com/hegemonic/taffydb/tarball/master",
+              "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
+            },
+            "underscore": {
+              "version": "1.4.4",
+              "from": "underscore@~1.4.2",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+            },
+            "wrench": {
+              "version": "1.3.9",
+              "from": "wrench@~1.3.9",
+              "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.3.9.tgz"
+            }
+          }
+        },
+        "taffydb": {
+          "version": "2.7.2",
+          "from": "taffydb@~2.7.2",
+          "resolved": "https://npm.webfilings.org/taffydb/-/taffydb-2.7.2.tgz"
+        },
+        "ink-docstrap": {
+          "version": "0.3.0-0",
+          "from": "ink-docstrap@~0.3.0-0",
+          "resolved": "https://npm.webfilings.org/ink-docstrap/-/ink-docstrap-0.3.0-0.tgz"
+        },
+        "wrench": {
+          "version": "1.5.8",
+          "from": "wrench@~1.5.6",
+          "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.5.8.tgz"
+        },
+        "marked": {
+          "version": "0.3.3",
+          "from": "marked@~0.3.1",
+          "resolved": "https://npm.webfilings.org/marked/-/marked-0.3.3.tgz"
+        }
+      }
+    },
+    "gulp-jshint": {
+      "version": "1.9.2",
+      "from": "gulp-jshint@^1.5.5",
+      "resolved": "https://npm.webfilings.org/gulp-jshint/-/gulp-jshint-1.9.2.tgz",
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
@@ -5086,290 +5830,12 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "2.0.0",
-              "from": "object-assign@^2.0.0",
-              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
-            },
-            "replace-ext": {
-              "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
-            },
-            "vinyl": {
-              "version": "0.4.6",
-              "from": "vinyl@^0.4.3",
-              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
-              "dependencies": {
-                "clone": {
-                  "version": "0.2.0",
-                  "from": "clone@^0.2.0",
-                  "resolved": "https://npm.webfilings.org/clone/-/clone-0.2.0.tgz"
-                },
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@^0.0.1",
-                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "minijasminenode2": {
-          "version": "1.0.0",
-          "from": "minijasminenode2@^1.0.0",
-          "resolved": "https://npm.webfilings.org/minijasminenode2/-/minijasminenode2-1.0.0.tgz",
-          "dependencies": {
-            "jasmine-core": {
-              "version": "2.0.0",
-              "from": "jasmine-core@2.0.0",
-              "resolved": "https://npm.webfilings.org/jasmine-core/-/jasmine-core-2.0.0.tgz"
-            }
-          }
-        },
-        "require-uncached": {
-          "version": "1.0.2",
-          "from": "require-uncached@^1.0.2",
-          "resolved": "https://npm.webfilings.org/require-uncached/-/require-uncached-1.0.2.tgz",
-          "dependencies": {
-            "caller-path": {
-              "version": "0.1.0",
-              "from": "caller-path@^0.1.0",
-              "resolved": "https://npm.webfilings.org/caller-path/-/caller-path-0.1.0.tgz",
-              "dependencies": {
-                "callsites": {
-                  "version": "0.2.0",
-                  "from": "callsites@^0.2.0",
-                  "resolved": "https://npm.webfilings.org/callsites/-/callsites-0.2.0.tgz"
-                }
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.0",
-              "from": "resolve-from@^1.0.0",
-              "resolved": "https://npm.webfilings.org/resolve-from/-/resolve-from-1.0.0.tgz"
-            }
-          }
-        },
-        "through2": {
-          "version": "0.6.3",
-          "from": "through2@^0.6.3",
-          "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-jsdoc": {
-      "version": "0.1.4",
-      "from": "gulp-jsdoc@^0.1.4",
-      "resolved": "https://npm.webfilings.org/gulp-jsdoc/-/gulp-jsdoc-0.1.4.tgz",
-      "dependencies": {
-        "through2": {
-          "version": "0.4.2",
-          "from": "through2@~0.4.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@~1.0.17",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@~1.0.0",
-                  "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@~0.10.x",
-                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "2.1.2",
-              "from": "xtend@~2.1.1",
-              "resolved": "https://npm.webfilings.org/xtend/-/xtend-2.1.2.tgz",
-              "dependencies": {
-                "object-keys": {
-                  "version": "0.4.0",
-                  "from": "object-keys@~0.4.0",
-                  "resolved": "https://npm.webfilings.org/object-keys/-/object-keys-0.4.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "from": "chalk@~0.4.0",
-          "resolved": "https://npm.webfilings.org/chalk/-/chalk-0.4.0.tgz",
-          "dependencies": {
-            "has-color": {
-              "version": "0.1.7",
-              "from": "has-color@~0.1.0",
-              "resolved": "https://npm.webfilings.org/has-color/-/has-color-0.1.7.tgz"
-            },
-            "ansi-styles": {
-              "version": "1.0.0",
-              "from": "ansi-styles@~1.0.0",
-              "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
-            },
-            "strip-ansi": {
-              "version": "0.1.1",
-              "from": "strip-ansi@~0.1.0",
-              "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@~0.2.0",
-          "resolved": "https://npm.webfilings.org/text-table/-/text-table-0.2.0.tgz"
-        },
-        "vinyl-fs": {
-          "version": "0.1.4",
-          "from": "vinyl-fs@~0.1.2",
-          "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.1.4.tgz",
-          "dependencies": {
-            "vinyl": {
-              "version": "0.2.3",
-              "from": "vinyl@^0.2.0",
-              "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.2.3.tgz",
-              "dependencies": {
-                "clone-stats": {
-                  "version": "0.0.1",
-                  "from": "clone-stats@~0.0.1",
-                  "resolved": "https://npm.webfilings.org/clone-stats/-/clone-stats-0.0.1.tgz"
-                }
-              }
-            },
-            "glob-stream": {
-              "version": "3.1.18",
-              "from": "glob-stream@^3.1.5",
-              "resolved": "https://npm.webfilings.org/glob-stream/-/glob-stream-3.1.18.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "2.0.1",
-                  "from": "minimatch@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-2.0.1.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.0",
-                      "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.2.0",
-                          "from": "balanced-match@^0.2.0",
-                          "resolved": "https://npm.webfilings.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "ordered-read-streams": {
-                  "version": "0.1.0",
-                  "from": "ordered-read-streams@^0.1.0",
-                  "resolved": "https://npm.webfilings.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
-                },
-                "glob2base": {
-                  "version": "0.0.12",
-                  "from": "glob2base@^0.0.12",
-                  "resolved": "https://npm.webfilings.org/glob2base/-/glob2base-0.0.12.tgz",
-                  "dependencies": {
-                    "find-index": {
-                      "version": "0.1.1",
-                      "from": "find-index@^0.1.1",
-                      "resolved": "https://npm.webfilings.org/find-index/-/find-index-0.1.1.tgz"
-                    }
-                  }
-                },
-                "unique-stream": {
-                  "version": "1.0.0",
-                  "from": "unique-stream@^1.0.0",
-                  "resolved": "https://npm.webfilings.org/unique-stream/-/unique-stream-1.0.0.tgz"
-                },
-                "through2": {
-                  "version": "0.6.3",
-                  "from": "through2@^0.6.1",
-                  "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
@@ -5379,7 +5845,7 @@
                         "isarray": {
                           "version": "0.0.1",
                           "from": "isarray@0.0.1",
-                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -5392,393 +5858,6 @@
                           "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
-                    },
-                    "xtend": {
-                      "version": "4.0.0",
-                      "from": "xtend@>=4.0.0 <4.1.0-0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "glob-watcher": {
-              "version": "0.0.6",
-              "from": "glob-watcher@^0.0.6",
-              "resolved": "https://npm.webfilings.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-              "dependencies": {
-                "gaze": {
-                  "version": "0.5.1",
-                  "from": "gaze@^0.5.1",
-                  "resolved": "https://npm.webfilings.org/gaze/-/gaze-0.5.1.tgz",
-                  "dependencies": {
-                    "globule": {
-                      "version": "0.1.0",
-                      "from": "globule@~0.1.0",
-                      "resolved": "https://npm.webfilings.org/globule/-/globule-0.1.0.tgz",
-                      "dependencies": {
-                        "lodash": {
-                          "version": "1.0.1",
-                          "from": "lodash@~1.0.1",
-                          "resolved": "https://npm.webfilings.org/lodash/-/lodash-1.0.1.tgz"
-                        },
-                        "glob": {
-                          "version": "3.1.21",
-                          "from": "glob@~3.1.21",
-                          "resolved": "https://npm.webfilings.org/glob/-/glob-3.1.21.tgz",
-                          "dependencies": {
-                            "inherits": {
-                              "version": "1.0.0",
-                              "from": "inherits@1",
-                              "resolved": "https://npm.webfilings.org/inherits/-/inherits-1.0.0.tgz"
-                            },
-                            "graceful-fs": {
-                              "version": "1.2.3",
-                              "from": "graceful-fs@~1.2.0",
-                              "resolved": "https://npm.webfilings.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
-                            }
-                          }
-                        },
-                        "minimatch": {
-                          "version": "0.2.14",
-                          "from": "minimatch@~0.2.11",
-                          "resolved": "https://npm.webfilings.org/minimatch/-/minimatch-0.2.14.tgz",
-                          "dependencies": {
-                            "sigmund": {
-                              "version": "1.0.0",
-                              "from": "sigmund@~1.0.0",
-                              "resolved": "https://npm.webfilings.org/sigmund/-/sigmund-1.0.0.tgz"
-                            },
-                            "lru-cache": {
-                              "version": "2.5.0",
-                              "from": "lru-cache@2",
-                              "resolved": "https://npm.webfilings.org/lru-cache/-/lru-cache-2.5.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.3.5",
-              "from": "mkdirp@^0.3.5",
-              "resolved": "https://npm.webfilings.org/mkdirp/-/mkdirp-0.3.5.tgz"
-            },
-            "graceful-fs": {
-              "version": "2.0.3",
-              "from": "graceful-fs@^2.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
-            },
-            "map-stream": {
-              "version": "0.1.0",
-              "from": "map-stream@^0.1.0",
-              "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.1.0.tgz"
-            }
-          }
-        },
-        "jsdoc": {
-          "version": "3.3.0-alpha5",
-          "from": "jsdoc@3.3.0-alpha5",
-          "resolved": "https://npm.webfilings.org/jsdoc/-/jsdoc-3.3.0-alpha5.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.1.22",
-              "from": "async@~0.1.22",
-              "resolved": "https://npm.webfilings.org/async/-/async-0.1.22.tgz"
-            },
-            "catharsis": {
-              "version": "0.7.1",
-              "from": "catharsis@~0.7.0",
-              "resolved": "https://npm.webfilings.org/catharsis/-/catharsis-0.7.1.tgz"
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "from": "esprima@~1.0.4",
-              "resolved": "https://npm.webfilings.org/esprima/-/esprima-1.0.4.tgz"
-            },
-            "js2xmlparser": {
-              "version": "0.1.9",
-              "from": "js2xmlparser@~0.1.0",
-              "resolved": "https://npm.webfilings.org/js2xmlparser/-/js2xmlparser-0.1.9.tgz"
-            },
-            "taffydb": {
-              "version": "2.6.2",
-              "from": "https://github.com/hegemonic/taffydb/tarball/master",
-              "resolved": "https://github.com/hegemonic/taffydb/tarball/master"
-            },
-            "underscore": {
-              "version": "1.4.4",
-              "from": "underscore@~1.4.2",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-            },
-            "wrench": {
-              "version": "1.3.9",
-              "from": "wrench@~1.3.9",
-              "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.3.9.tgz"
-            }
-          }
-        },
-        "taffydb": {
-          "version": "2.7.2",
-          "from": "taffydb@~2.7.2",
-          "resolved": "https://npm.webfilings.org/taffydb/-/taffydb-2.7.2.tgz"
-        },
-        "ink-docstrap": {
-          "version": "0.3.0-0",
-          "from": "ink-docstrap@~0.3.0-0",
-          "resolved": "https://npm.webfilings.org/ink-docstrap/-/ink-docstrap-0.3.0-0.tgz"
-        },
-        "wrench": {
-          "version": "1.5.8",
-          "from": "wrench@~1.5.6",
-          "resolved": "https://npm.webfilings.org/wrench/-/wrench-1.5.8.tgz"
-        },
-        "marked": {
-          "version": "0.3.3",
-          "from": "marked@~0.3.1",
-          "resolved": "https://npm.webfilings.org/marked/-/marked-0.3.3.tgz"
-        }
-      }
-    },
-    "gulp-jshint": {
-      "version": "1.9.2",
-      "from": "gulp-jshint@^1.5.5",
-      "resolved": "https://npm.webfilings.org/gulp-jshint/-/gulp-jshint-1.9.2.tgz",
-      "dependencies": {
-        "gulp-util": {
-          "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
-          "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
-          "dependencies": {
-            "array-differ": {
-              "version": "1.0.0",
-              "from": "array-differ@^1.0.0",
-              "resolved": "https://npm.webfilings.org/array-differ/-/array-differ-1.0.0.tgz"
-            },
-            "array-uniq": {
-              "version": "1.0.2",
-              "from": "array-uniq@^1.0.2",
-              "resolved": "https://npm.webfilings.org/array-uniq/-/array-uniq-1.0.2.tgz"
-            },
-            "beeper": {
-              "version": "1.0.0",
-              "from": "beeper@^1.0.0",
-              "resolved": "https://npm.webfilings.org/beeper/-/beeper-1.0.0.tgz"
-            },
-            "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://npm.webfilings.org/chalk/-/chalk-1.0.0.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.0.1",
-                  "from": "ansi-styles@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://npm.webfilings.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
-                  "resolved": "https://npm.webfilings.org/has-ansi/-/has-ansi-1.0.3.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
-                      "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
-                  "resolved": "https://npm.webfilings.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "1.3.0",
-                  "from": "supports-color@^1.3.0",
-                  "resolved": "https://npm.webfilings.org/supports-color/-/supports-color-1.3.0.tgz"
-                }
-              }
-            },
-            "dateformat": {
-              "version": "1.0.11",
-              "from": "dateformat@^1.0.11",
-              "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@*",
-                  "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "meow": {
-                  "version": "3.1.0",
-                  "from": "meow@*",
-                  "resolved": "https://npm.webfilings.org/meow/-/meow-3.1.0.tgz",
-                  "dependencies": {
-                    "camelcase-keys": {
-                      "version": "1.0.0",
-                      "from": "camelcase-keys@^1.0.0",
-                      "resolved": "https://npm.webfilings.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.0.2",
-                          "from": "camelcase@^1.0.1",
-                          "resolved": "https://npm.webfilings.org/camelcase/-/camelcase-1.0.2.tgz"
-                        },
-                        "map-obj": {
-                          "version": "1.0.0",
-                          "from": "map-obj@^1.0.0",
-                          "resolved": "https://npm.webfilings.org/map-obj/-/map-obj-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "indent-string": {
-                      "version": "1.2.1",
-                      "from": "indent-string@^1.1.0",
-                      "resolved": "https://npm.webfilings.org/indent-string/-/indent-string-1.2.1.tgz",
-                      "dependencies": {
-                        "repeating": {
-                          "version": "1.1.2",
-                          "from": "repeating@^1.1.0",
-                          "resolved": "https://npm.webfilings.org/repeating/-/repeating-1.1.2.tgz",
-                          "dependencies": {
-                            "is-finite": {
-                              "version": "1.0.0",
-                              "from": "is-finite@^1.0.0",
-                              "resolved": "https://npm.webfilings.org/is-finite/-/is-finite-1.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._reescape": {
-              "version": "3.0.0",
-              "from": "lodash._reescape@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
-            },
-            "lodash._reevaluate": {
-              "version": "3.0.0",
-              "from": "lodash._reevaluate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
-            },
-            "lodash._reinterpolate": {
-              "version": "3.0.0",
-              "from": "lodash._reinterpolate@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
-            },
-            "lodash.template": {
-              "version": "3.3.2",
-              "from": "lodash.template@^3.0.0",
-              "resolved": "https://npm.webfilings.org/lodash.template/-/lodash.template-3.3.2.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.0",
-                  "from": "lodash._basecopy@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basecopy/-/lodash._basecopy-3.0.0.tgz"
-                },
-                "lodash._basetostring": {
-                  "version": "3.0.0",
-                  "from": "lodash._basetostring@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
-                },
-                "lodash._basevalues": {
-                  "version": "3.0.0",
-                  "from": "lodash._basevalues@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
-                },
-                "lodash._isiterateecall": {
-                  "version": "3.0.4",
-                  "from": "lodash._isiterateecall@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.4.tgz"
-                },
-                "lodash.escape": {
-                  "version": "3.0.0",
-                  "from": "lodash.escape@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.0.4",
-                  "from": "lodash.keys@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.keys/-/lodash.keys-3.0.4.tgz",
-                  "dependencies": {
-                    "lodash.isarguments": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarguments@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarguments/-/lodash.isarguments-3.0.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.0",
-                      "from": "lodash.isarray@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isarray/-/lodash.isarray-3.0.0.tgz"
-                    },
-                    "lodash.isnative": {
-                      "version": "3.0.0",
-                      "from": "lodash.isnative@^3.0.0",
-                      "resolved": "https://npm.webfilings.org/lodash.isnative/-/lodash.isnative-3.0.0.tgz"
-                    }
-                  }
-                },
-                "lodash.templatesettings": {
-                  "version": "3.1.0",
-                  "from": "lodash.templatesettings@^3.0.0",
-                  "resolved": "https://npm.webfilings.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
-                }
-              }
-            },
-            "minimist": {
-              "version": "1.1.0",
-              "from": "minimist@^1.1.0",
-              "resolved": "https://npm.webfilings.org/minimist/-/minimist-1.1.0.tgz"
-            },
-            "multipipe": {
-              "version": "0.1.2",
-              "from": "multipipe@^0.1.2",
-              "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
-              "dependencies": {
-                "duplexer2": {
-                  "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.1.10",
-                      "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
-                        }
-                      }
                     }
                   }
                 }
@@ -5792,7 +5871,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -5836,7 +5915,7 @@
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "concat-map@0.0.1",
-                  "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -5845,7 +5924,7 @@
         "rcloader": {
           "version": "0.1.2",
           "from": "rcloader@0.1.2",
-          "resolved": "https://npm.webfilings.org/rcloader/-/rcloader-0.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
           "dependencies": {
             "rcfinder": {
               "version": "0.1.8",
@@ -5861,7 +5940,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.3",
+          "from": "through2@~0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -5877,7 +5956,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -5903,7 +5982,7 @@
     "gulp-karma": {
       "version": "0.0.4",
       "from": "gulp-karma@0.0.4",
-      "resolved": "https://npm.webfilings.org/gulp-karma/-/gulp-karma-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-karma/-/gulp-karma-0.0.4.tgz",
       "dependencies": {
         "optimist": {
           "version": "0.6.1",
@@ -5962,7 +6041,7 @@
             "pause-stream": {
               "version": "0.0.11",
               "from": "pause-stream@0.0.11",
-              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
             },
             "split": {
               "version": "0.2.10",
@@ -5971,7 +6050,7 @@
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "stream-combiner@~0.0.3",
+              "from": "stream-combiner@~0.0.4",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
             }
           }
@@ -5981,7 +6060,7 @@
     "gulp-livereload": {
       "version": "2.1.0",
       "from": "gulp-livereload@2.1.0",
-      "resolved": "https://npm.webfilings.org/gulp-livereload/-/gulp-livereload-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-2.1.0.tgz",
       "dependencies": {
         "lodash.merge": {
           "version": "2.4.1",
@@ -6299,7 +6378,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -6318,7 +6397,7 @@
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@*",
                   "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
@@ -6453,22 +6532,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -6484,7 +6573,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -6507,7 +6596,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.3",
+          "from": "through2@~0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6523,7 +6612,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -6553,7 +6642,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@>=3.0.0 <4.0.0-0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -6764,22 +6853,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -6795,7 +6894,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -6830,7 +6929,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.1",
+          "from": "through2@>=0.6.1 <1.0.0-0",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6846,7 +6945,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -6870,22 +6969,32 @@
         "bufferstreams": {
           "version": "0.0.2",
           "from": "bufferstreams@0.0.2",
-          "resolved": "https://npm.webfilings.org/bufferstreams/-/bufferstreams-0.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-0.0.2.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.1.10",
-              "from": "readable-stream@^1.0.26-2",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.17",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
                   "from": "core-util-is@~1.0.0",
                   "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "debuglog": {
-                  "version": "0.0.2",
-                  "from": "debuglog@0.0.2",
-                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             }
@@ -6894,11 +7003,11 @@
         "memory-cache": {
           "version": "0.0.5",
           "from": "memory-cache@0.0.5",
-          "resolved": "https://npm.webfilings.org/memory-cache/-/memory-cache-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.0.5.tgz"
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@^0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
           "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
         }
       }
@@ -6967,7 +7076,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "ansi-regex@^1.0.0",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -7121,22 +7230,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -7152,7 +7271,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -7175,7 +7294,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.3",
+          "from": "through2@~0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -7191,7 +7310,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -7221,7 +7340,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.1",
+          "from": "gulp-util@~3.0.3",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -7297,7 +7416,7 @@
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@*",
                   "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
@@ -7432,22 +7551,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -7463,7 +7592,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -7507,7 +7636,7 @@
                 "escomplex-ast-moz": {
                   "version": "0.1.6",
                   "from": "escomplex-ast-moz@0.1.6",
-                  "resolved": "https://npm.webfilings.org/escomplex-ast-moz/-/escomplex-ast-moz-0.1.6.tgz",
+                  "resolved": "https://registry.npmjs.org/escomplex-ast-moz/-/escomplex-ast-moz-0.1.6.tgz",
                   "dependencies": {
                     "escomplex-traits": {
                       "version": "0.2.0",
@@ -7519,7 +7648,7 @@
                 "escomplex": {
                   "version": "1.2.0",
                   "from": "escomplex@1.2.0",
-                  "resolved": "https://npm.webfilings.org/escomplex/-/escomplex-1.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/escomplex/-/escomplex-1.2.0.tgz",
                   "dependencies": {
                     "matrix-utilities": {
                       "version": "1.2.4",
@@ -7583,7 +7712,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
+                  "from": "inherits@2",
                   "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -7604,7 +7733,7 @@
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -7638,7 +7767,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@~0.6.3",
+          "from": "through2@~0.6",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -7654,7 +7783,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -7684,7 +7813,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0",
+          "from": "gulp-util@~3.0.3",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -7741,7 +7870,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -7895,22 +8024,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -7926,7 +8065,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -7965,7 +8104,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -7989,13 +8128,13 @@
       }
     },
     "gulp-react": {
-      "version": "2.1.0",
+      "version": "2.0.0",
       "from": "gulp-react@^2.0.0",
-      "resolved": "https://npm.webfilings.org/gulp-react/-/gulp-react-2.1.0.tgz",
+      "resolved": "https://npm.webfilings.org/gulp-react/-/gulp-react-2.0.0.tgz",
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@>=3.0.0 <4.0.0-0",
+          "from": "gulp-util@3.0.4",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -8052,7 +8191,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -8071,7 +8210,7 @@
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
+                  "from": "get-stdin@*",
                   "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
@@ -8206,22 +8345,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -8229,10 +8378,15 @@
                 }
               }
             },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@^2.0.0",
+              "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -8253,15 +8407,10 @@
             }
           }
         },
-        "object-assign": {
-          "version": "2.0.0",
-          "from": "object-assign@^2.0.0",
-          "resolved": "https://npm.webfilings.org/object-assign/-/object-assign-2.0.0.tgz"
-        },
         "react-tools": {
-          "version": "0.13.0-rc2",
-          "from": "react-tools@^0.13.0-rc1",
-          "resolved": "https://npm.webfilings.org/react-tools/-/react-tools-0.13.0-rc2.tgz",
+          "version": "0.12.2",
+          "from": "react-tools@^0.12.0",
+          "resolved": "https://npm.webfilings.org/react-tools/-/react-tools-0.12.2.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.1",
@@ -8319,7 +8468,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
+                      "from": "inherits@~2.0.1",
                       "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -8371,19 +8520,19 @@
               }
             },
             "jstransform": {
-              "version": "10.1.0",
-              "from": "jstransform@^10.0.0",
-              "resolved": "https://npm.webfilings.org/jstransform/-/jstransform-10.1.0.tgz",
+              "version": "8.2.0",
+              "from": "jstransform@^8.2.0",
+              "resolved": "https://npm.webfilings.org/jstransform/-/jstransform-8.2.0.tgz",
               "dependencies": {
                 "base62": {
                   "version": "0.1.1",
                   "from": "base62@0.1.1",
-                  "resolved": "https://npm.webfilings.org/base62/-/base62-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
-                  "version": "13001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
-                  "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                  "version": "8001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@8001.1001.0-dev-harmony-fb",
+                  "resolved": "https://npm.webfilings.org/esprima-fb/-/esprima-fb-8001.1001.0-dev-harmony-fb.tgz"
                 },
                 "source-map": {
                   "version": "0.1.31",
@@ -8419,7 +8568,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -8439,11 +8588,6 @@
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
-        },
-        "vinyl-sourcemaps-apply": {
-          "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
-          "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
         }
       }
     },
@@ -8527,7 +8671,7 @@
         },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@>=3.0.0 <4.0.0-0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -8738,22 +8882,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -8769,7 +8923,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "through2": {
               "version": "0.6.3",
@@ -8778,7 +8932,7 @@
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "readable-stream@~1.0.26-2",
                   "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
@@ -8789,7 +8943,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -8843,12 +8997,12 @@
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@~0.9.0",
+          "from": "async@^0.9.0",
           "resolved": "https://npm.webfilings.org/async/-/async-0.9.0.tgz"
         },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@^3.0.0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -8905,7 +9059,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
+                      "from": "ansi-regex@1.1.1",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -9059,22 +9213,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -9090,7 +9254,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -9113,7 +9277,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.3",
+          "from": "through2@~0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -9129,7 +9293,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -9185,7 +9349,7 @@
             "pause-stream": {
               "version": "0.0.11",
               "from": "pause-stream@0.0.11",
-              "resolved": "https://npm.webfilings.org/pause-stream/-/pause-stream-0.0.11.tgz"
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
             },
             "split": {
               "version": "0.2.10",
@@ -9194,7 +9358,7 @@
             },
             "stream-combiner": {
               "version": "0.0.4",
-              "from": "stream-combiner@~0.0.3",
+              "from": "stream-combiner@~0.0.4",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
             }
           }
@@ -9229,7 +9393,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -9269,7 +9433,7 @@
         },
         "vinyl-fs": {
           "version": "0.3.13",
-          "from": "vinyl-fs@^0.3.4",
+          "from": "vinyl-fs@^0.3.0",
           "resolved": "https://npm.webfilings.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
           "dependencies": {
             "defaults": {
@@ -9307,7 +9471,7 @@
                         "concat-map": {
                           "version": "0.0.1",
                           "from": "concat-map@0.0.1",
-                          "resolved": "https://npm.webfilings.org/concat-map/-/concat-map-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
                     }
@@ -9437,7 +9601,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -9460,7 +9624,7 @@
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@^0.4.3",
+              "from": "vinyl@^0.4.0",
               "resolved": "https://npm.webfilings.org/vinyl/-/vinyl-0.4.6.tgz",
               "dependencies": {
                 "clone": {
@@ -9496,7 +9660,7 @@
       "dependencies": {
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@^3.0.0",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -9707,22 +9871,32 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -9738,7 +9912,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "through2": {
               "version": "0.6.3",
@@ -9758,7 +9932,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -9815,7 +9989,7 @@
             },
             "rcfinder": {
               "version": "0.1.8",
-              "from": "rcfinder@^0.1.6",
+              "from": "rcfinder@0.1.8",
               "resolved": "https://npm.webfilings.org/rcfinder/-/rcfinder-0.1.8.tgz",
               "dependencies": {
                 "lodash": {
@@ -9911,7 +10085,7 @@
         },
         "gulp-util": {
           "version": "3.0.4",
-          "from": "gulp-util@^3.0.2",
+          "from": "gulp-util@^3.0.1",
           "resolved": "https://npm.webfilings.org/gulp-util/-/gulp-util-3.0.4.tgz",
           "dependencies": {
             "array-differ": {
@@ -9951,7 +10125,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "ansi-regex@^1.1.0",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     },
                     "get-stdin": {
@@ -9968,7 +10142,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "1.1.1",
-                      "from": "ansi-regex@^1.0.0",
+                      "from": "ansi-regex@^1.1.0",
                       "resolved": "https://npm.webfilings.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
                     }
                   }
@@ -10121,23 +10295,33 @@
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@~0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.1.10",
+                      "version": "1.1.13",
                       "from": "readable-stream@~1.1.9",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
                           "from": "core-util-is@~1.0.0",
                           "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
-                        "debuglog": {
-                          "version": "0.0.2",
-                          "from": "debuglog@0.0.2",
-                          "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1",
+                          "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
                     }
@@ -10153,7 +10337,7 @@
             "replace-ext": {
               "version": "0.0.1",
               "from": "replace-ext@0.0.1",
-              "resolved": "https://npm.webfilings.org/replace-ext/-/replace-ext-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             },
             "vinyl": {
               "version": "0.4.6",
@@ -10176,7 +10360,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@^0.6.1",
+          "from": "through2@>=0.6.1 <1.0.0-0",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -10192,7 +10376,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -10216,7 +10400,7 @@
         "uglify-js": {
           "version": "2.4.16",
           "from": "uglify-js@2.4.16",
-          "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -10256,7 +10440,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@^0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
           "resolved": "https://npm.webfilings.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz"
         }
       }
@@ -10444,28 +10628,38 @@
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@^0.1.0",
+          "from": "multipipe@^0.1.2",
           "resolved": "https://npm.webfilings.org/multipipe/-/multipipe-0.1.2.tgz",
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
               "from": "duplexer2@0.0.2",
-              "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.10",
+                  "version": "1.1.13",
                   "from": "readable-stream@~1.1.9",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "debuglog": {
-                      "version": "0.0.2",
-                      "from": "debuglog@0.0.2",
-                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 }
@@ -10480,7 +10674,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@1.0.33",
+              "from": "readable-stream@~1.0.17",
               "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -10491,7 +10685,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -10534,7 +10728,7 @@
         "map-stream": {
           "version": "0.0.4",
           "from": "map-stream@0.0.4",
-          "resolved": "https://npm.webfilings.org/map-stream/-/map-stream-0.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz"
         }
       }
     },
@@ -10636,19 +10830,29 @@
               "resolved": "https://npm.webfilings.org/domelementtype/-/domelementtype-1.3.0.tgz"
             },
             "readable-stream": {
-              "version": "1.1.10",
+              "version": "1.1.13",
               "from": "readable-stream@1.1",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
                   "from": "core-util-is@~1.0.0",
                   "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "debuglog": {
-                  "version": "0.0.2",
-                  "from": "debuglog@0.0.2",
-                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
@@ -10793,18 +10997,13 @@
         "socket.io": {
           "version": "0.9.16",
           "from": "socket.io@0.9.16",
-          "resolved": "https://npm.webfilings.org/socket.io/-/socket.io-0.9.16.tgz",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
           "dependencies": {
             "socket.io-client": {
               "version": "0.9.16",
               "from": "socket.io-client@0.9.16",
-              "resolved": "https://npm.webfilings.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-0.9.16.tgz",
               "dependencies": {
-                "xmlhttprequest": {
-                  "version": "1.4.2",
-                  "from": "xmlhttprequest@1.4.2",
-                  "resolved": "https://npm.webfilings.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
-                },
                 "uglify-js": {
                   "version": "1.2.5",
                   "from": "uglify-js@1.2.5",
@@ -10837,34 +11036,39 @@
                     }
                   }
                 },
+                "xmlhttprequest": {
+                  "version": "1.4.2",
+                  "from": "xmlhttprequest@1.4.2",
+                  "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz"
+                },
                 "active-x-obfuscator": {
                   "version": "0.0.1",
                   "from": "active-x-obfuscator@0.0.1",
-                  "resolved": "https://npm.webfilings.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
                   "dependencies": {
                     "zeparser": {
                       "version": "0.0.5",
                       "from": "zeparser@0.0.5",
-                      "resolved": "https://npm.webfilings.org/zeparser/-/zeparser-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz"
                     }
                   }
                 }
               }
             },
-            "base64id": {
-              "version": "0.1.0",
-              "from": "base64id@0.1.0",
-              "resolved": "https://npm.webfilings.org/base64id/-/base64id-0.1.0.tgz"
-            },
             "policyfile": {
               "version": "0.0.4",
               "from": "policyfile@0.0.4",
-              "resolved": "https://npm.webfilings.org/policyfile/-/policyfile-0.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz"
+            },
+            "base64id": {
+              "version": "0.1.0",
+              "from": "base64id@0.1.0",
+              "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
             },
             "redis": {
               "version": "0.7.3",
               "from": "redis@0.7.3",
-              "resolved": "https://npm.webfilings.org/redis/-/redis-0.7.3.tgz"
+              "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz"
             }
           }
         },
@@ -10944,7 +11148,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -11108,7 +11312,7 @@
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "readable-stream@~1.0.2",
               "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -11119,7 +11323,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -11165,7 +11369,7 @@
             "basic-auth-connect": {
               "version": "1.0.0",
               "from": "basic-auth-connect@1.0.0",
-              "resolved": "https://npm.webfilings.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
             },
             "body-parser": {
               "version": "1.8.4",
@@ -11180,12 +11384,12 @@
                 "on-finished": {
                   "version": "2.1.0",
                   "from": "on-finished@2.1.0",
-                  "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
                       "from": "ee-first@1.0.5",
-                      "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 },
@@ -11199,12 +11403,12 @@
             "bytes": {
               "version": "1.0.0",
               "from": "bytes@1.0.0",
-              "resolved": "https://npm.webfilings.org/bytes/-/bytes-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
             },
             "cookie": {
               "version": "0.1.2",
               "from": "cookie@0.1.2",
-              "resolved": "https://npm.webfilings.org/cookie/-/cookie-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
             },
             "cookie-parser": {
               "version": "1.3.4",
@@ -11259,7 +11463,7 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@>= 1.1.2 < 2",
+                      "from": "mime-db@~1.7.0",
                       "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
@@ -11279,7 +11483,7 @@
                 "ms": {
                   "version": "0.6.2",
                   "from": "ms@0.6.2",
-                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
@@ -11296,7 +11500,7 @@
                     "base64-url": {
                       "version": "1.2.1",
                       "from": "base64-url@1.2.1",
-                      "resolved": "https://npm.webfilings.org/base64-url/-/base64-url-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     },
                     "rndm": {
                       "version": "1.1.0",
@@ -11349,14 +11553,14 @@
                 "ms": {
                   "version": "0.6.2",
                   "from": "ms@0.6.2",
-                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
             "depd": {
               "version": "0.4.5",
               "from": "depd@0.4.5",
-              "resolved": "https://npm.webfilings.org/depd/-/depd-0.4.5.tgz"
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
             },
             "errorhandler": {
               "version": "1.2.4",
@@ -11390,7 +11594,7 @@
                 "escape-html": {
                   "version": "1.0.1",
                   "from": "escape-html@1.0.1",
-                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
@@ -11402,12 +11606,12 @@
                 "crc": {
                   "version": "3.0.0",
                   "from": "crc@3.0.0",
-                  "resolved": "https://npm.webfilings.org/crc/-/crc-3.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                 },
                 "uid-safe": {
                   "version": "1.0.1",
                   "from": "uid-safe@1.0.1",
-                  "resolved": "https://npm.webfilings.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
                   "dependencies": {
                     "mz": {
                       "version": "1.3.0",
@@ -11434,26 +11638,26 @@
                     "base64-url": {
                       "version": "1.2.1",
                       "from": "base64-url@1",
-                      "resolved": "https://npm.webfilings.org/base64-url/-/base64-url-1.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
                     }
                   }
                 },
                 "utils-merge": {
                   "version": "1.0.0",
                   "from": "utils-merge@1.0.0",
-                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
             "finalhandler": {
               "version": "0.2.0",
               "from": "finalhandler@0.2.0",
-              "resolved": "https://npm.webfilings.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
               "dependencies": {
                 "escape-html": {
                   "version": "1.0.1",
                   "from": "escape-html@1.0.1",
-                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 }
               }
             },
@@ -11465,7 +11669,7 @@
             "media-typer": {
               "version": "0.3.0",
               "from": "media-typer@0.3.0",
-              "resolved": "https://npm.webfilings.org/media-typer/-/media-typer-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
             },
             "method-override": {
               "version": "2.2.0",
@@ -11492,17 +11696,17 @@
                 "basic-auth": {
                   "version": "1.0.0",
                   "from": "basic-auth@1.0.0",
-                  "resolved": "https://npm.webfilings.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
                 },
                 "on-finished": {
                   "version": "2.1.0",
                   "from": "on-finished@2.1.0",
-                  "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                   "dependencies": {
                     "ee-first": {
                       "version": "1.0.5",
                       "from": "ee-first@1.0.5",
-                      "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                     }
                   }
                 }
@@ -11514,19 +11718,29 @@
               "resolved": "https://npm.webfilings.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.10",
+                  "version": "1.1.13",
                   "from": "readable-stream@~1.1.9",
-                  "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@~1.0.0",
                       "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
-                    "debuglog": {
-                      "version": "0.0.2",
-                      "from": "debuglog@0.0.2",
-                      "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1",
+                      "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
@@ -11577,7 +11791,7 @@
                 "ms": {
                   "version": "0.6.2",
                   "from": "ms@0.6.2",
-                  "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                 }
               }
             },
@@ -11625,7 +11839,7 @@
                 "escape-html": {
                   "version": "1.0.1",
                   "from": "escape-html@1.0.1",
-                  "resolved": "https://npm.webfilings.org/escape-html/-/escape-html-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
                 },
                 "send": {
                   "version": "0.9.3",
@@ -11635,7 +11849,7 @@
                     "destroy": {
                       "version": "1.0.3",
                       "from": "destroy@1.0.3",
-                      "resolved": "https://npm.webfilings.org/destroy/-/destroy-1.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                     },
                     "etag": {
                       "version": "1.4.0",
@@ -11645,24 +11859,24 @@
                         "crc": {
                           "version": "3.0.0",
                           "from": "crc@3.0.0",
-                          "resolved": "https://npm.webfilings.org/crc/-/crc-3.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
                         }
                       }
                     },
                     "ms": {
                       "version": "0.6.2",
                       "from": "ms@0.6.2",
-                      "resolved": "https://npm.webfilings.org/ms/-/ms-0.6.2.tgz"
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
                     },
                     "on-finished": {
                       "version": "2.1.0",
                       "from": "on-finished@2.1.0",
-                      "resolved": "https://npm.webfilings.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
                       "dependencies": {
                         "ee-first": {
                           "version": "1.0.5",
                           "from": "ee-first@1.0.5",
-                          "resolved": "https://npm.webfilings.org/ee-first/-/ee-first-1.0.5.tgz"
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
                         }
                       }
                     },
@@ -11676,7 +11890,7 @@
                 "utils-merge": {
                   "version": "1.0.0",
                   "from": "utils-merge@1.0.0",
-                  "resolved": "https://npm.webfilings.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
                 }
               }
             },
@@ -11692,7 +11906,7 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.7.0",
-                      "from": "mime-db@>= 1.1.2 < 2",
+                      "from": "mime-db@~1.7.0",
                       "resolved": "https://npm.webfilings.org/mime-db/-/mime-db-1.7.0.tgz"
                     }
                   }
@@ -11707,7 +11921,7 @@
             "pause": {
               "version": "0.0.1",
               "from": "pause@0.0.1",
-              "resolved": "https://npm.webfilings.org/pause/-/pause-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         }
@@ -11731,7 +11945,7 @@
                 "jsonparse": {
                   "version": "0.0.5",
                   "from": "jsonparse@0.0.5",
-                  "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                 },
                 "through": {
                   "version": "2.3.6",
@@ -11758,7 +11972,7 @@
                     "jsonparse": {
                       "version": "0.0.5",
                       "from": "jsonparse@0.0.5",
-                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.2.7",
@@ -11832,7 +12046,7 @@
                 "base64-js": {
                   "version": "0.0.7",
                   "from": "base64-js@0.0.7",
-                  "resolved": "https://npm.webfilings.org/base64-js/-/base64-js-0.0.7.tgz"
+                  "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.7.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.4",
@@ -11854,7 +12068,7 @@
             "commondir": {
               "version": "0.0.1",
               "from": "commondir@0.0.1",
-              "resolved": "https://npm.webfilings.org/commondir/-/commondir-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
             },
             "concat-stream": {
               "version": "1.4.7",
@@ -11865,6 +12079,28 @@
                   "version": "0.0.6",
                   "from": "typedarray@~0.0.5",
                   "resolved": "https://npm.webfilings.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@~1.1.9",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
                 }
               }
             },
@@ -11893,7 +12129,7 @@
                 "ripemd160": {
                   "version": "0.2.0",
                   "from": "ripemd160@0.2.0",
-                  "resolved": "https://npm.webfilings.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
                 },
                 "sha.js": {
                   "version": "2.1.6",
@@ -11949,7 +12185,7 @@
                     "jsonparse": {
                       "version": "0.0.5",
                       "from": "jsonparse@0.0.5",
-                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.2.7",
@@ -12054,7 +12290,7 @@
                     "jsonparse": {
                       "version": "0.0.5",
                       "from": "jsonparse@0.0.5",
-                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     }
                   }
                 },
@@ -12102,7 +12338,7 @@
                     "jsonparse": {
                       "version": "0.0.5",
                       "from": "jsonparse@0.0.5",
-                      "resolved": "https://npm.webfilings.org/jsonparse/-/jsonparse-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
                     },
                     "through": {
                       "version": "2.3.6",
@@ -12153,7 +12389,31 @@
                 "duplexer2": {
                   "version": "0.0.2",
                   "from": "duplexer2@0.0.2",
-                  "resolved": "https://npm.webfilings.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@~1.1.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@~1.0.0",
+                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x",
+                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        }
+                      }
+                    }
+                  }
                 },
                 "minimist": {
                   "version": "0.0.10",
@@ -12187,28 +12447,6 @@
                   "from": "through2@~0.4.1",
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
                   "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.17",
-                      "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.1",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        }
-                      }
-                    },
                     "xtend": {
                       "version": "2.1.2",
                       "from": "xtend@~2.1.1",
@@ -12258,19 +12496,24 @@
               "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
-              "version": "1.1.10",
-              "from": "readable-stream@^1.0.33-1",
-              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.1.10.tgz",
+              "version": "1.0.33",
+              "from": "readable-stream@^1.0.27-1",
+              "resolved": "https://npm.webfilings.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
                   "from": "core-util-is@~1.0.0",
                   "resolved": "https://npm.webfilings.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
-                "debuglog": {
-                  "version": "0.0.2",
-                  "from": "debuglog@0.0.2",
-                  "resolved": "https://npm.webfilings.org/debuglog/-/debuglog-0.0.2.tgz"
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://npm.webfilings.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 }
               }
             },
@@ -12282,7 +12525,7 @@
             "shallow-copy": {
               "version": "0.0.1",
               "from": "shallow-copy@0.0.1",
-              "resolved": "https://npm.webfilings.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
             },
             "shell-quote": {
               "version": "0.0.1",
@@ -12307,7 +12550,7 @@
             "subarg": {
               "version": "0.0.1",
               "from": "subarg@0.0.1",
-              "resolved": "https://npm.webfilings.org/subarg/-/subarg-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.10",
@@ -12346,7 +12589,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -12435,7 +12678,7 @@
                 "uglify-js": {
                   "version": "2.4.16",
                   "from": "uglify-js@~2.4.0",
-                  "resolved": "https://npm.webfilings.org/uglify-js/-/uglify-js-2.4.16.tgz",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
                   "dependencies": {
                     "async": {
                       "version": "0.2.10",
@@ -12488,7 +12731,7 @@
                 "querystring": {
                   "version": "0.2.0",
                   "from": "querystring@0.2.0",
-                  "resolved": "https://npm.webfilings.org/querystring/-/querystring-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
@@ -12505,7 +12748,7 @@
                 "indexof": {
                   "version": "0.0.1",
                   "from": "indexof@0.0.1",
-                  "resolved": "https://npm.webfilings.org/indexof/-/indexof-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
             },
@@ -12570,7 +12813,7 @@
             "recursive-readdir": {
               "version": "0.0.2",
               "from": "recursive-readdir@0.0.2",
-              "resolved": "https://npm.webfilings.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-0.0.2.tgz"
             }
           }
         },
@@ -12773,7 +13016,7 @@
             },
             "optimist": {
               "version": "0.6.1",
-              "from": "optimist@~0.6.0",
+              "from": "optimist@~0.6.1",
               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
               "dependencies": {
                 "wordwrap": {
@@ -12816,12 +13059,12 @@
         },
         "dateformat": {
           "version": "1.0.11",
-          "from": "dateformat@^1.0.11",
+          "from": "dateformat@~1.0.6",
           "resolved": "https://npm.webfilings.org/dateformat/-/dateformat-1.0.11.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@*",
+              "from": "get-stdin@^4.0.1",
               "resolved": "https://npm.webfilings.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
@@ -12962,7 +13205,7 @@
         "xmlbuilder": {
           "version": "0.4.2",
           "from": "xmlbuilder@0.4.2",
-          "resolved": "https://npm.webfilings.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
         }
       }
     },
@@ -13060,7 +13303,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -13164,7 +13407,7 @@
                         "isarray": {
                           "version": "0.0.1",
                           "from": "isarray@0.0.1",
-                          "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
@@ -13203,7 +13446,7 @@
                         "delayed-stream": {
                           "version": "0.0.5",
                           "from": "delayed-stream@0.0.5",
-                          "resolved": "https://npm.webfilings.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                         }
                       }
                     },
@@ -13264,12 +13507,12 @@
                     "asn1": {
                       "version": "0.1.11",
                       "from": "asn1@0.1.11",
-                      "resolved": "https://npm.webfilings.org/asn1/-/asn1-0.1.11.tgz"
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                     },
                     "ctype": {
                       "version": "0.5.3",
                       "from": "ctype@0.5.3",
-                      "resolved": "https://npm.webfilings.org/ctype/-/ctype-0.5.3.tgz"
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                     }
                   }
                 },
@@ -13281,7 +13524,7 @@
                 "hawk": {
                   "version": "1.1.1",
                   "from": "hawk@1.1.1",
-                  "resolved": "https://npm.webfilings.org/hawk/-/hawk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
                   "dependencies": {
                     "hoek": {
                       "version": "0.9.1",
@@ -13375,7 +13618,7 @@
       "dependencies": {
         "through2": {
           "version": "0.6.3",
-          "from": "through2@~0.6.3",
+          "from": "through2@~0.6",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -13391,7 +13634,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
@@ -13400,7 +13643,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@~2.0.0",
+                  "from": "inherits@~2.0.1",
                   "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -13429,7 +13672,7 @@
     "open": {
       "version": "0.0.5",
       "from": "open@0.0.5",
-      "resolved": "https://npm.webfilings.org/open/-/open-0.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
     },
     "partialify": {
       "version": "3.1.3",
@@ -13439,7 +13682,7 @@
         "string-to-js": {
           "version": "0.0.1",
           "from": "string-to-js@0.0.1",
-          "resolved": "https://npm.webfilings.org/string-to-js/-/string-to-js-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/string-to-js/-/string-to-js-0.0.1.tgz"
         },
         "through": {
           "version": "2.3.6",
@@ -13451,12 +13694,12 @@
     "phantomjs": {
       "version": "1.9.15",
       "from": "phantomjs@1.9.15",
-      "resolved": "https://npm.webfilings.org/phantomjs/-/phantomjs-1.9.15.tgz",
+      "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.15.tgz",
       "dependencies": {
         "adm-zip": {
           "version": "0.4.4",
           "from": "adm-zip@0.4.4",
-          "resolved": "https://npm.webfilings.org/adm-zip/-/adm-zip-0.4.4.tgz"
+          "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
         },
         "fs-extra": {
           "version": "0.16.5",
@@ -13483,12 +13726,12 @@
         "kew": {
           "version": "0.4.0",
           "from": "kew@0.4.0",
-          "resolved": "https://npm.webfilings.org/kew/-/kew-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
         },
         "npmconf": {
           "version": "2.0.9",
           "from": "npmconf@2.0.9",
-          "resolved": "https://npm.webfilings.org/npmconf/-/npmconf-2.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.0.9.tgz",
           "dependencies": {
             "config-chain": {
               "version": "1.1.8",
@@ -13504,7 +13747,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
+              "from": "inherits@~2.0.0",
               "resolved": "https://npm.webfilings.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
@@ -13549,19 +13792,19 @@
             "uid-number": {
               "version": "0.0.5",
               "from": "uid-number@0.0.5",
-              "resolved": "https://npm.webfilings.org/uid-number/-/uid-number-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
             }
           }
         },
         "progress": {
           "version": "1.1.8",
           "from": "progress@1.1.8",
-          "resolved": "https://npm.webfilings.org/progress/-/progress-1.1.8.tgz"
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
         "request": {
           "version": "2.42.0",
           "from": "request@2.42.0",
-          "resolved": "https://npm.webfilings.org/request/-/request-2.42.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
           "dependencies": {
             "bl": {
               "version": "0.9.4",
@@ -13581,7 +13824,7 @@
                     "isarray": {
                       "version": "0.0.1",
                       "from": "isarray@0.0.1",
-                      "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
@@ -13657,7 +13900,7 @@
                     "delayed-stream": {
                       "version": "0.0.5",
                       "from": "delayed-stream@0.0.5",
-                      "resolved": "https://npm.webfilings.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
                     }
                   }
                 },
@@ -13686,12 +13929,12 @@
                 "asn1": {
                   "version": "0.1.11",
                   "from": "asn1@0.1.11",
-                  "resolved": "https://npm.webfilings.org/asn1/-/asn1-0.1.11.tgz"
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
                 },
                 "ctype": {
                   "version": "0.5.3",
                   "from": "ctype@0.5.3",
-                  "resolved": "https://npm.webfilings.org/ctype/-/ctype-0.5.3.tgz"
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
                 }
               }
             },
@@ -13703,7 +13946,7 @@
             "hawk": {
               "version": "1.1.1",
               "from": "hawk@1.1.1",
-              "resolved": "https://npm.webfilings.org/hawk/-/hawk-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "0.9.1",
@@ -13742,7 +13985,7 @@
         "request-progress": {
           "version": "0.3.1",
           "from": "request-progress@0.3.1",
-          "resolved": "https://npm.webfilings.org/request-progress/-/request-progress-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
           "dependencies": {
             "throttleit": {
               "version": "0.0.2",
@@ -13781,7 +14024,7 @@
                 "base62": {
                   "version": "0.1.1",
                   "from": "base62@0.1.1",
-                  "resolved": "https://npm.webfilings.org/base62/-/base62-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
                 },
                 "esprima-fb": {
                   "version": "13001.1001.0-dev-harmony-fb",
@@ -13826,7 +14069,7 @@
     "tiny-lr": {
       "version": "0.0.7",
       "from": "tiny-lr@0.0.7",
-      "resolved": "https://npm.webfilings.org/tiny-lr/-/tiny-lr-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.0.7.tgz",
       "dependencies": {
         "qs": {
           "version": "0.5.6",
@@ -13893,7 +14136,7 @@
         },
         "through2": {
           "version": "0.6.3",
-          "from": "through2@>=0.6.1 <1.0.0-0",
+          "from": "through2@^0.6.1",
           "resolved": "https://npm.webfilings.org/through2/-/through2-0.6.3.tgz",
           "dependencies": {
             "readable-stream": {
@@ -13909,7 +14152,7 @@
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://npm.webfilings.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "test": "multi='xunit=xunit.xml tap=-' mocha test/**/*.spec.js --reporter mocha-multi"
   },
   "peerDependencies": {
-    "gulp": "^3.8.7",
-    "intern": "^2.2.2"
+    "gulp": "^3.8.7"
   },
   "dependencies": {
     "browserify": "^6.1.0",


### PR DESCRIPTION
## Summary
- wGulp dependency changes have broken wGulp multiple times so use `npm shrinkwrap` to lock dependencies down to current state

## Testing
- travis CI is happy

@maxwellpeterson-wf 
@evanweible-wf 
@jayudey-wf 