### PR TITLE
CP-467 Add copy:ts task to be used during test runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Out of the box wGulp provides a *lot* of functionality. It is a collection of be
     copy:htmltest - Copy html templates in ./test/ to ./build/test/
     copy:js - Copy JavaScript files in ./src/ to ./build/src/
     copy:jstest - Copy JavaScript files in ./test/ to ./build/test/
+    copy:ts - Copy TypeScript files in ./src/ to ./build/src/
     cover - Generate and view code coverage report
     customize - Copy the standard config files to your project for customization
     default - Execute the tasks specified in default

--- a/src/applyLanguageOptions.js
+++ b/src/applyLanguageOptions.js
@@ -25,7 +25,7 @@ module.exports = function(options, languages){
         javascript: ['copy:js', 'jshint', 'minify:js', 'copy:jstest'],
         jsx: ['jsx', 'jsx:test'],
         livescript: ['livescript'],
-        typescript: ['tsd', 'tsc', 'tslint', 'tsc:test']
+        typescript: ['copy:ts', 'tsd', 'tsc', 'tslint', 'tsc:test']
     };
 
     var allLanguages = Object.keys(langMap);

--- a/src/gulpconfig.json
+++ b/src/gulpconfig.json
@@ -59,6 +59,7 @@
         "copy:htmltest": ["clean:buildTest"],
         "copy:js": ["clean:buildSrc"],
         "copy:jstest": ["clean:buildTest"],
+        "copy:ts": ["clean:buildSrc", "tsc"],
         "cover": ["test"],
         "jasmine": ["preTest"],
         "jsdoc": ["build"],
@@ -84,7 +85,7 @@
         "bundle": ["clean:dist", "build"],
         "default": ["clean", "build", "test", "analyze", "jsdoc", "dist"],
         "dist": ["clean", "build", "bundle", "libraryDist", "minify:css"],
-        "preTest": ["build", "tsc:test", "copy:htmltest", "copy:jstest", "jsx:test"],
+        "preTest": ["build", "tsc:test", "copy:htmltest", "copy:jstest", "jsx:test", "copy:ts"],
         "test": ["preTest", "karma"],
         "test:jasmine": ["preTest", "jasmine"]
     },

--- a/src/tasks/defaults.js
+++ b/src/tasks/defaults.js
@@ -104,6 +104,14 @@ module.exports = function(gulp, options, subtasks) {
         changed: true
     }));
 
+    gulp.desc('copy:ts', 'Copy TS from src to buildSrc');
+    gulp.task('copy:ts', getDeps(options, 'copy:ts'), subtasks.copy({
+        glob: options.glob.ts,
+        cwd: options.path.src,
+        dest: options.path.buildSrc,
+        changed: true
+    }));
+
     gulp.desc('copy:htmltest', 'Copy HTML from test to buildTest');
     gulp.task('copy:htmltest', getDeps(options, 'copy:htmltest'), subtasks.copy({
         glob: options.glob.html,


### PR DESCRIPTION
## Description

This copies the `.ts` files into the buildSrc directory during test runs so that typescript sourcemaps work when debugging test.

It will only run this task if the `typescript` language is chosen.

## Testing

When using this branch of wGulp with a typescript project (like wSession)... you should see typescript files in `./build/src/` after running `gulp test`

FYA:
@trentgrover-wf 
@evanweible-wf 