### PR TITLE
CP-531 Pin typescript dependency to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "requirejs": "^2.1.14",
     "source-map": "^0.1.33",
     "tiny-lr": "0.0.7",
-    "typescript": "^1.4.1",
+    "typescript": "1.4.1",
     "vinyl-source-stream": "^1.0.0",
     "yargs": "^1.2.1"
   },


### PR DESCRIPTION
## Issue
- TypeScript released a [1.5.0-alpha](https://github.com/Microsoft/TypeScript/releases/tag/v1.5.0-alpha) version that will be pulled down by the current `^1.4.1` semver range.

## Changes
**Source:**
- Pinned the `typescript` dependency to 1.4.1 in `package.json`

**Tests:**
- N/a

## Areas of Regression
- TypeScript installation/compilation

## Testing
- A wGulp project using this branch should install the 1.4.1 version of the TypeScript compiler

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 