### PR TITLE
CP-620 Pin karma dependency to known-working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gulp-wait": "^0.0.2",
     "jshint": "^2.5.0",
     "jshint-stylish": "^1.0.0",
-    "karma": "^0.12.23",
+    "karma": "0.12.31",
     "karma-browserifast": "^0.7.0",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.1.4",


### PR DESCRIPTION
## Issue
wGulp consumers may be getting this error during test runs:

```bash
INFO [karma]: Karma v0.12.32 server started at http://localhost:9876/
INFO [launcher]: Starting browser Chrome
INFO [Chrome 42.0.2311 (Mac OS X 10.10.3)]: Connected on socket tke92Pt4nxcrth8XAAAA with id 14994834
ERROR [karma]: Uncaught ReferenceError: jasmineRequire is not defined
at http://localhost:9876/base/node_modules/wGulp/node_modules/karma-jasmine-html-reporter-livereload/src/lib/html.jasmine.reporter.js?fa4cadff90361c3ec47708eb7dced39e8903df19:24
```

It has been determined that this is not an issue with the previous karma version, 0.12.31. This issue is being tracked [here](https://github.com/taras42/karma-jasmine-html-reporter/issues/4), perhaps a better fix or a new version of karma will come out of it.

## Changes
**Source:**
- Change karma dependency to be pinned at 0.12.31.

**Tests:**
- N/A

## Areas of Regression
- Test runs with wGulp

## Testing
- A repo such as wSession using a freshly installed wGulp should exhibit the error described above.
- Installing this branch of wGulp instead should fix the error.

@trentgrover-wf 
@evanweible-wf 