### PR TITLE
CP-648 Upgrade gulp-sass.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-plumber": "^0.6.2",
     "gulp-react": "^2.0.0",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^0.7.2",
+    "gulp-sass": "^2.0.1",
     "gulp-shell": "^0.2.8",
     "gulp-tap": "^0.1.1",
     "gulp-tsc": "^0.9.0",


### PR DESCRIPTION
## Issue
The `gulp-sass` plugin depends on a `node-sass` version that uses an old `libsass`. As a result, wGulp fails to compile SASS after web-skin@1.1.0. Fixes #150.

Before this change the following error would occur in Certifier-client (which just upgraded to web-skin 1.1.0):

```bash
[14:10:53] 'sass' errored after 273 ms
[14:10:53] Error in plugin 'sass'
./node_modules/web-skin/sass/core/api/helpers/functions/utilities/check-dependencies:76: error: only variable declarations and control directives are allowed inside functions
```

## Changes
**Source:**
- Upgrade to `gulp-sass@2.0.1`

**Tests:**
- No change.

## Areas of Regression
- The `sass` task

## Testing
- sass test passes

@evanweible-wf 
@jayudey-wf 
Will want a patch release after this.

FYI
@aaronlademann-wf 
@theisensanders-wf 