### PR TITLE
CP-965 Pin jshint to 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^2.2.19",
     "gulp-wait": "^0.0.2",
-    "jshint": "^2.5.0",
+    "jshint": "2.8.0",
     "jshint-stylish": "^1.0.0",
     "karma": "0.12.31",
     "karma-browserifast": "^0.7.0",


### PR DESCRIPTION
## Issue
An issue in jshint 2.9.0 is causing wGulp builds to fail incorrectly: https://ci.webfilings.com/build/365338

Reported by @theisensanders-wf 

## Changes
**Source:**
- Pin jshint to version 2.8.0


## Areas of Regression
- None

## Testing
- CI passes

@trentgrover-wf 
@evanweible-wf 
@dustinlessard-wf 
FYI @jayudey-wf