### PR TITLE
Pin node-sass to satisfy upstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lodash": "^2.4.1",
     "merge-stream": "^0.1.5",
     "mkdirp": "^0.5.0",
+    "node-sass": "3.3.0",
     "open": "0.0.5",
     "partialify": "^3.1.1",
     "phantomjs": "1.9.15",


### PR DESCRIPTION
Code Review
----

#### Ultimate Problem
An upstream dependency of wGulp was itself pulling in a beta version of `node-sass` which was causing errors in some projects when they attempted to run `gulp sass`.

#### Proposed Solution
Add `node-sass: 3.3.0` to wGulp's dependencies, which satisfies the upstream dependency and prevents the beta version from being included in the dependency tree.