### PR TITLE
CP-1211 Upgrade to gulp-connect 2.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-coffee": "^2.0.1",
     "gulp-compass": "^1.3.1",
     "gulp-concat": "^2.3.5",
-    "gulp-connect": "^2.0.5",
+    "gulp-connect": "^2.3.1",
     "gulp-flatten": "^0.0.4",
     "gulp-header": "^1.0.5",
     "gulp-istanbul": "^0.3.1",


### PR DESCRIPTION
>Just a heads-up that the `gulp-connect` packaged required in `wGulp` has some broken stuff in its latest release which affects Smithy builds.  There is a new release in the pipeline, however: https://github.com/AveVlad/gulp-connect/releases/tag/2.3.1  Fix was released 12 minutes ago.

Reported by @jimhotchkin-wf 

## Changes
**Source:**
- Update gulp-connect dependency

## Testing
- CI Passes
- @jimhotchkin-wf would you be able to supply a testing +10 for this PR?

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf