### PR TITLE
CP-2588 Switch from gulp-jsdoc to gulp-jsdoc3 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-header": "^1.0.5",
     "gulp-istanbul": "^0.3.1",
     "gulp-jasmine": "^1.0.1",
-    "gulp-jsdoc": "^0.1.4",
+    "gulp-jsdoc3": "^0.2.0",
     "gulp-jshint": "^1.5.5",
     "gulp-karma": "0.0.4",
     "gulp-livereload": "2.1.0",

--- a/src/subtasks/jsdoc.js
+++ b/src/subtasks/jsdoc.js
@@ -23,7 +23,7 @@ module.exports = function(gulp, defaults) {
 
         return function (cb) {
             var gutil = require('gulp-util');
-            var jsdoc = require('gulp-jsdoc');
+            var jsdoc = require('gulp-jsdoc3');
 
             var stream;
             if(config.src)
@@ -34,11 +34,11 @@ module.exports = function(gulp, defaults) {
                 });
             }
 
-            return stream.pipe(jsdoc.parser())
+            return stream.pipe(jsdoc(cb))
                 .on('error', function(err){
                     cb(new gutil.PluginError('jsdoc', err));
                 })
-                .pipe(jsdoc.generator(config.dest || defaults.path.docs));
+                .pipe(gulp.dest(config.dest || defaults.path.docs));
         };
     };
 };

--- a/test/subtasks/jsdoc.spec.js
+++ b/test/subtasks/jsdoc.spec.js
@@ -10,7 +10,7 @@ describe("jsdoc subtask", function() {
         var docOutput = helper.options.path.docs;
 
         var jsdoc = require('../../src/subtasks/jsdoc')(gulp, helper.options);
-        jsdoc({cwd: "./test/subtasks/fixtures/coverage/js/"})();
+        jsdoc({cwd: "./test/subtasks/fixtures/js/"})();
         if (!fs.existsSync(docOutput)) {
             throw new Error("JSDoc output not found");
         }


### PR DESCRIPTION
`gulp-jsdoc` has been deprecated in favor of `gulp-jsdoc3` because apparently people don't understand the problem semver solves.

Hoping this will fix builds that depend on wGulps'd docs task: https://github.com/Workiva/wf-home-html/pull/506

@Workiva/client-platform-pp 
